### PR TITLE
fix: use classNames in lieu of $$props.class

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@codemirror/lang-javascript": "^6.1.5",
     "@turf/turf": "^6.5.0",
+    "classnames": "^2.3.2",
     "codemirror": "^6.0.1",
     "d3": "^7.8.2",
     "lodash.camelcase": "^4.3.0",

--- a/src/lib/components/shared/Button.svelte
+++ b/src/lib/components/shared/Button.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
+  import cs from 'classnames';
+
+  let className = '';
+  export { className as class };
 
   const dispatch = createEventDispatcher();
   function click() {
@@ -9,6 +13,6 @@
 
 <button
   on:click={click}
-  class="rounded bg-slate-700 px-4 py-2 text-sm text-white {$$props.class}"
+  class={cs('rounded bg-slate-700 px-4 py-2 text-sm text-white', className)}
   ><slot /></button
 >

--- a/src/lib/components/shared/Menu.svelte
+++ b/src/lib/components/shared/Menu.svelte
@@ -1,3 +1,10 @@
-<div class="stack-border rounded-md bg-slate-900 {$$props.class}">
+<script lang="ts">
+  import cs from 'classnames';
+
+  let className = '';
+  export { className as class };
+</script>
+
+<div class={cs('stack-border rounded-md bg-slate-900', className)}>
   <slot />
 </div>

--- a/src/lib/components/shared/MenuTitle.svelte
+++ b/src/lib/components/shared/MenuTitle.svelte
@@ -1,6 +1,13 @@
+<script lang="ts">
+  import cs from 'classnames';
+
+  let className = '';
+  export { className as class };
+</script>
+
 {#if $$slots.action}
   <div class="flex items-center justify-between p-4 text-white">
-    <p class="font-sans text-xl font-medium tracking-wider {$$props.class}">
+    <p class={cs('font-sans text-xl font-medium tracking-wider', className)}>
       <slot />
     </p>
     <slot name="action" />

--- a/src/lib/components/shared/NumberInput.svelte
+++ b/src/lib/components/shared/NumberInput.svelte
@@ -1,11 +1,15 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
+  import cs from 'classnames';
 
   export let min: number = 0;
   export let max: number = Infinity;
   export let step: number = 1;
   export let value: number;
   export let disabled: boolean = false;
+
+  let className = '';
+  export { className as class };
 
   const dispatch = createEventDispatcher();
 
@@ -23,7 +27,10 @@
   {step}
   {disabled}
   on:change={onChange}
-  class="border border-transparent bg-inherit p-2 hover:border-slate-600 focus:border-slate-600 {$$props.class}"
+  class={cs(
+    'border border-transparent bg-inherit p-2 hover:border-slate-600 focus:border-slate-600',
+    className
+  )}
 />
 
 <style>

--- a/src/lib/components/shared/Portal.svelte
+++ b/src/lib/components/shared/Portal.svelte
@@ -5,6 +5,9 @@
   let ref: HTMLDivElement;
   let portal: HTMLDivElement;
 
+  let className = '';
+  export { className as class };
+
   onMount(() => {
     portal = document.createElement('div');
     target.appendChild(portal);
@@ -17,7 +20,7 @@
 </script>
 
 <div class="hidden">
-  <div bind:this={ref} class={$$props.class} style={$$props.style}>
+  <div bind:this={ref} class={className} style={$$props.style}>
     <slot />
   </div>
 </div>

--- a/src/lib/components/shared/Select.svelte
+++ b/src/lib/components/shared/Select.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
+  import cs from 'classnames';
 
   import FieldLabel from '$lib/components/shared/FieldLabel.svelte';
 
@@ -14,6 +15,9 @@
   export let options: SelectOption<T>[] = [];
   export let title: string = '';
   let ref: HTMLSelectElement | HTMLDivElement;
+
+  let className = '';
+  export { className as class };
 
   const dispatch = createEventDispatcher();
 
@@ -33,7 +37,10 @@
       {title}
     </FieldLabel>
     <select
-      class="border border-transparent bg-inherit p-2 hover:border-slate-600 focus:border-slate-600 {$$props.class}"
+      class={cs(
+        'border border-transparent bg-inherit p-2 hover:border-slate-600 focus:border-slate-600',
+        className
+      )}
       value={selected}
       on:change={onChange}
       id={title}
@@ -47,7 +54,10 @@
   </div>
 {:else}
   <select
-    class="border border-transparent bg-inherit p-2 hover:border-slate-600 focus:border-slate-600 {$$props.class}"
+    class={cs(
+      'border border-transparent bg-inherit p-2 hover:border-slate-600 focus:border-slate-600',
+      className
+    )}
     value={selected}
     on:change={onChange}
     bind:this={ref}

--- a/src/lib/components/shared/Tabs.svelte
+++ b/src/lib/components/shared/Tabs.svelte
@@ -7,10 +7,14 @@
 
 <script lang="ts">
   import type { SvelteComponent } from 'svelte';
+  import cs from 'classnames';
 
   export let tabs: Tab[] = [];
 
   let activeIndex = 0;
+
+  let className = '';
+  export { className as class };
 
   function setActiveTab(i: number) {
     return function onTabClick() {
@@ -20,7 +24,7 @@
 </script>
 
 <div class="stack">
-  <ul class="stack-h stack-h-md {$$props.class}">
+  <ul class={cs('stack-h stack-h-md', className)}>
     {#each tabs as tab, i}
       <li
         class="border-b-2 pb-2 text-base transition-all duration-200"

--- a/src/lib/components/shared/TextInput.svelte
+++ b/src/lib/components/shared/TextInput.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
+  import cs from 'classnames';
 
   export let value: string;
   export let placeholder = '';
   export let id = '';
+
+  let className = '';
+  export { className as class };
 
   const dispatch = createEventDispatcher();
 
@@ -18,5 +22,8 @@
   {placeholder}
   {id}
   on:change={onChange}
-  class="border border-slate-700 bg-inherit p-2 hover:border-slate-600 focus:border-slate-600 {$$props.class}"
+  class={cs(
+    'border border-slate-700 bg-inherit p-2 hover:border-slate-600 focus:border-slate-600',
+    className
+  )}
 />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2176,6 +2176,11 @@ chownr@^2.0.0:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
+classnames@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
+  integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
+
 codemirror@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-6.0.1.tgz#62b91142d45904547ee3e0e0e4c1a79158035a29"


### PR DESCRIPTION
This PR makes a decision around the "classes-as-component-props" problem. In React, it's quite common to expose a `className` prop that allows parents to style children according to presentational context. In Svelte, the pattern [referenced in the docs](https://svelte.dev/docs#component-format-script-1-export-creates-a-component-prop) is to `export` a `className` prop as `class`. This works even though `class` is a reserved keyword!

```ts
let className = '';

export { className as class };
```

This works nicely, but we still hit a snag when we want to conjunct a `class` passed as a prop with an existing string of Tailwind classes. For this, we use `classnames` to conditionally add `class` only if it is defined. This means we avoid things liked `undefined` or a trailing space showing up in our HTML markup.

Some folks mentioned using `$$props.class` as well to get around this. This works (in fact, we used it previously), but it feels a bit like an abuse of the internals. All of this is extremely pedantic, but alas, what is writing CSS if not (righteous) pedantry.