### PR TITLE
Fix #11. Add support for configurable stroke.

### DIFF
--- a/src/lib/codegen/codegen-layer.ts
+++ b/src/lib/codegen/codegen-layer.ts
@@ -43,7 +43,7 @@ export function codegenLayer(layer: CartoKitLayer): string {
           type: 'circle',
           ${
             fill || stroke
-              ? `paint: { ${fill ? fill + ',\n' : ''} ${stroke} }`
+              ? `paint: { ${[fill, stroke].filter(Boolean).join(',\n')} }`
               : ''
           }
         });

--- a/src/lib/codegen/codegen-layer.ts
+++ b/src/lib/codegen/codegen-layer.ts
@@ -12,55 +12,36 @@ export function codegenLayer(layer: CartoKitLayer): string {
   switch (layer.type) {
     case 'Fill':
     case 'Choropleth': {
-      const paint = codegenPaint(layer);
+      const { fill, stroke } = codegenPaint(layer);
 
       return `
-			map.addLayer({
-				id: '${layer.id}',
-				source: '${layer.id}',
-				type: 'fill',
-				${
-          paint.fill
-            ? `paint: {
-					${paint.fill}
-				}`
-            : ''
-        }
-			});
+map.addLayer({
+	id: '${layer.id}',
+	source: '${layer.id}',
+	type: 'fill',
+	${fill ? `paint: { ${fill} }` : ''}
+});
 
-			map.addLayer({
-				id: '${layer.id}-stroke',
-				source: '${layer.id}',
-				type: 'line',
-				${
-          paint.stroke
-            ? `paint: {
-					${paint.stroke}
-				}`
-            : ''
-        }
-			});
-			`;
+map.addLayer({
+	id: '${layer.id}-stroke',
+	source: '${layer.id}',
+	type: 'line',
+	${stroke ? `paint: { ${stroke} }` : ''}
+});
+`;
     }
     case 'Proportional Symbol':
     case 'Dot Density': {
-      const paint = codegenPaint(layer);
+      const { fill, stroke } = codegenPaint(layer);
 
       return `
-			map.addLayer({
-				id: '${layer.id}',
-				source: '${layer.id}',
-				type: 'circle',
-				${
-          paint.fill || paint.stroke
-            ? `paint: {
-					${paint.fill},
-					${paint.stroke}
-				}`
-            : ''
-        }
-			});
-			`;
+map.addLayer({
+	id: '${layer.id}',
+	source: '${layer.id}',
+	type: 'circle',
+	${fill || stroke ? `paint: { ${fill ? fill + ',\n' : ''} ${stroke} }` : ''}
+});
+`;
     }
   }
 }

--- a/src/lib/codegen/codegen-layer.ts
+++ b/src/lib/codegen/codegen-layer.ts
@@ -15,33 +15,37 @@ export function codegenLayer(layer: CartoKitLayer): string {
       const { fill, stroke } = codegenPaint(layer);
 
       return `
-map.addLayer({
-	id: '${layer.id}',
-	source: '${layer.id}',
-	type: 'fill',
-	${fill ? `paint: { ${fill} }` : ''}
-});
+        map.addLayer({
+          id: '${layer.id}',
+          source: '${layer.id}',
+          type: 'fill',
+          ${fill ? `paint: { ${fill} }` : ''}
+        });
 
-map.addLayer({
-	id: '${layer.id}-stroke',
-	source: '${layer.id}',
-	type: 'line',
-	${stroke ? `paint: { ${stroke} }` : ''}
-});
-`;
+        map.addLayer({
+          id: '${layer.id}-stroke',
+          source: '${layer.id}',
+          type: 'line',
+          ${stroke ? `paint: { ${stroke} }` : ''}
+        });
+      `;
     }
     case 'Proportional Symbol':
     case 'Dot Density': {
       const { fill, stroke } = codegenPaint(layer);
 
       return `
-map.addLayer({
-	id: '${layer.id}',
-	source: '${layer.id}',
-	type: 'circle',
-	${fill || stroke ? `paint: { ${fill ? fill + ',\n' : ''} ${stroke} }` : ''}
-});
-`;
+        map.addLayer({
+          id: '${layer.id}',
+          source: '${layer.id}',
+          type: 'circle',
+          ${
+            fill || stroke
+              ? `paint: { ${fill ? fill + ',\n' : ''} ${stroke} }`
+              : ''
+          }
+        });
+      `;
     }
   }
 }

--- a/src/lib/codegen/codegen-layer.ts
+++ b/src/lib/codegen/codegen-layer.ts
@@ -1,4 +1,4 @@
-import { codegenPaint } from '$lib/codegen/codegen-paint';
+import { codegenFill, codegenStroke } from '$lib/codegen/codegen-paint';
 import type { CartoKitLayer } from '$lib/types/CartoKitLayer';
 
 /**
@@ -12,7 +12,8 @@ export function codegenLayer(layer: CartoKitLayer): string {
   switch (layer.type) {
     case 'Fill':
     case 'Choropleth': {
-      const { fill, stroke } = codegenPaint(layer);
+      const fill = codegenFill(layer);
+      const stroke = codegenStroke(layer);
 
       return `
         map.addLayer({
@@ -32,7 +33,8 @@ export function codegenLayer(layer: CartoKitLayer): string {
     }
     case 'Proportional Symbol':
     case 'Dot Density': {
-      const { fill, stroke } = codegenPaint(layer);
+      const fill = codegenFill(layer);
+      const stroke = codegenStroke(layer);
 
       return `
         map.addLayer({

--- a/src/lib/codegen/codegen-layer.ts
+++ b/src/lib/codegen/codegen-layer.ts
@@ -19,7 +19,26 @@ export function codegenLayer(layer: CartoKitLayer): string {
 				id: '${layer.id}',
 				source: '${layer.id}',
 				type: 'fill',
-				${paint}
+				${
+          paint.fill
+            ? `paint: {
+					${paint.fill}
+				}`
+            : ''
+        }
+			});
+
+			map.addLayer({
+				id: '${layer.id}-stroke',
+				source: '${layer.id}',
+				type: 'line',
+				${
+          paint.stroke
+            ? `paint: {
+					${paint.stroke}
+				}`
+            : ''
+        }
 			});
 			`;
     }
@@ -32,7 +51,14 @@ export function codegenLayer(layer: CartoKitLayer): string {
 				id: '${layer.id}',
 				source: '${layer.id}',
 				type: 'circle',
-				${paint}
+				${
+          paint.fill || paint.stroke
+            ? `paint: {
+					${paint.fill},
+					${paint.stroke}
+				}`
+            : ''
+        }
 			});
 			`;
     }

--- a/src/lib/codegen/codegen-paint.ts
+++ b/src/lib/codegen/codegen-paint.ts
@@ -13,74 +13,70 @@ import { MAPBOX_DEFAULTS } from '$lib/utils/constants';
 export function codegenFill(layer: CartoKitLayer): string {
   switch (layer.type) {
     case 'Fill': {
-      return intersperse(
-        [
-          withDefault(
-            'fill-color',
-            layer.style.fill,
-            MAPBOX_DEFAULTS['fill-color']
-          ),
-          withDefault(
-            'fill-opacity',
-            layer.style.opacity,
-            MAPBOX_DEFAULTS['fill-opacity']
-          )
-        ],
-        ',\n'
-      );
+      return [
+        withDefault(
+          'fill-color',
+          layer.style.fill,
+          MAPBOX_DEFAULTS['fill-color']
+        ),
+        withDefault(
+          'fill-opacity',
+          layer.style.opacity,
+          MAPBOX_DEFAULTS['fill-opacity']
+        )
+      ]
+        .filter(Boolean)
+        .join(',\n');
     }
     case 'Choropleth': {
-      return intersperse(
-        [
-          `'fill-color': ${JSON.stringify(deriveColorScale(layer))}`,
-          withDefault(
-            'fill-opacity',
-            layer.style.opacity,
-            MAPBOX_DEFAULTS['fill-opacity']
-          )
-        ],
-        ',\n'
-      );
+      return [
+        `'fill-color': ${JSON.stringify(deriveColorScale(layer))}`,
+        withDefault(
+          'fill-opacity',
+          layer.style.opacity,
+          MAPBOX_DEFAULTS['fill-opacity']
+        )
+      ]
+        .filter(Boolean)
+        .join(',\n');
     }
     case 'Proportional Symbol': {
-      return intersperse(
-        [
-          withDefault(
-            'circle-color',
-            layer.style.fill,
-            MAPBOX_DEFAULTS['circle-color']
-          ),
-          `'circle-radius': ${JSON.stringify(deriveSize(layer))}`,
-          withDefault(
-            'circle-opacity',
-            layer.style.opacity,
-            MAPBOX_DEFAULTS['fill-opacity']
-          )
-        ],
-        ',\n'
-      );
+      return [
+        withDefault(
+          'circle-color',
+          layer.style.fill,
+          MAPBOX_DEFAULTS['circle-color']
+        ),
+        `'circle-radius': ${JSON.stringify(deriveSize(layer))}`,
+        withDefault(
+          'circle-opacity',
+          layer.style.opacity,
+          MAPBOX_DEFAULTS['fill-opacity']
+        )
+      ]
+        .filter(Boolean)
+        .join(',\n');
     }
     case 'Dot Density': {
-      return intersperse(
-        [
-          withDefault(
-            'circle-color',
-            layer.style.fill,
-            MAPBOX_DEFAULTS['circle-color']
-          ),
-          withDefault(
-            'circle-radius',
-            layer.style.dots.size,
-            MAPBOX_DEFAULTS['circle-radius']
-          ),
-          withDefault(
-            'circle-opacity',
-            layer.style.opacity,
-            MAPBOX_DEFAULTS['circle-opacity']
-          )
-        ],
-        ',\n'
-      );
+      return [
+        withDefault(
+          'circle-color',
+          layer.style.fill,
+          MAPBOX_DEFAULTS['circle-color']
+        ),
+        withDefault(
+          'circle-radius',
+          layer.style.dots.size,
+          MAPBOX_DEFAULTS['circle-radius']
+        ),
+        withDefault(
+          'circle-opacity',
+          layer.style.opacity,
+          MAPBOX_DEFAULTS['circle-opacity']
+        )
+      ]
+        .filter(Boolean)
+        .join(',\n');
     }
   }
 }
@@ -95,39 +91,37 @@ export function codegenStroke(layer: CartoKitLayer): string {
   switch (layer.type) {
     case 'Fill':
     case 'Choropleth': {
-      return intersperse(
-        [
-          withDefault(
-            'line-color',
-            layer.style.stroke,
-            MAPBOX_DEFAULTS['line-color']
-          ),
-          withDefault(
-            'line-width',
-            layer.style.strokeWidth,
-            MAPBOX_DEFAULTS['line-width']
-          )
-        ],
-        ',\n'
-      );
+      return [
+        withDefault(
+          'line-color',
+          layer.style.stroke,
+          MAPBOX_DEFAULTS['line-color']
+        ),
+        withDefault(
+          'line-width',
+          layer.style.strokeWidth,
+          MAPBOX_DEFAULTS['line-width']
+        )
+      ]
+        .filter(Boolean)
+        .join(',\n');
     }
     case 'Proportional Symbol':
     case 'Dot Density': {
-      return intersperse(
-        [
-          withDefault(
-            'circle-stroke-color',
-            layer.style.stroke,
-            MAPBOX_DEFAULTS['circle-stroke-color']
-          ),
-          withDefault(
-            'circle-stroke-width',
-            layer.style.strokeWidth,
-            MAPBOX_DEFAULTS['circle-stroke-width']
-          )
-        ],
-        ',\n'
-      );
+      return [
+        withDefault(
+          'circle-stroke-color',
+          layer.style.stroke,
+          MAPBOX_DEFAULTS['circle-stroke-color']
+        ),
+        withDefault(
+          'circle-stroke-width',
+          layer.style.strokeWidth,
+          MAPBOX_DEFAULTS['circle-stroke-width']
+        )
+      ]
+        .filter(Boolean)
+        .join(',\n');
     }
   }
 }
@@ -152,25 +146,4 @@ function withDefault<T extends string | number>(
         typeof cartokitValue === 'string' ? `'${cartokitValue}'` : cartokitValue
       }`
     : '';
-}
-
-/**
- * Interperse a set of values by a separator (without leaving a dangling
- * separator after the last value).
- *
- * @param values — The input array of values to separate.
- * @param sep – A string separator between values.
- * @returns – A string with values separated by @param sep.
- */
-function intersperse(values: string[], sep: string): string {
-  const v = values.filter(Boolean);
-
-  switch (v.length) {
-    case 0:
-      return '';
-    case 1:
-      return v[0];
-    default:
-      return v.slice(1).reduce((acc, el) => acc.concat(`${sep}${el}`), v[0]);
-  }
 }

--- a/src/lib/codegen/codegen-paint.ts
+++ b/src/lib/codegen/codegen-paint.ts
@@ -1,56 +1,152 @@
 import { deriveColorScale } from '$lib/interaction/color';
 import { deriveSize } from '$lib/interaction/geometry';
 import type { CartoKitLayer } from '$lib/types/CartoKitLayer';
-import {
-  DEFAULT_FILL,
-  DEFAULT_OPACITY,
-  DEFAULT_RADIUS
-} from '$lib/utils/constants';
+import { MAPBOX_DEFAULTS } from '$lib/utils/constants';
 
 /**
- * Generate a Mapbox GL JS program fragment representing the layer's
- * presentational properties.
+ * Generate a Mapbox GL JS program fragment representing the layer's paint
+ * properties.
  *
  * @param layer – A CartoKit layer.
  *
- * @returns – A Mapbox GL JS program fragment representing the layer's
- * presentational properties.
+ * @returns – A Mapbox GL JS program fragment representing the layer's paint
+ * properties.
  */
-export function codegenPaint(layer: CartoKitLayer): string {
+export function codegenPaint(layer: CartoKitLayer): {
+  fill: string;
+  stroke: string;
+} {
+  return {
+    fill: codegenFill(layer),
+    stroke: codegenStroke(layer)
+  };
+}
+
+/**
+ * Generate a Mapbox GL JS program fragment representing the layer's fill.
+ *
+ * @param layer – A CartoKit layer.
+ *
+ * @returns – A Mapbox GL JS program fragment representing the layer's fill.
+ */
+function codegenFill(layer: CartoKitLayer): string {
   switch (layer.type) {
     case 'Fill': {
-      if (
-        layer.style.fill === DEFAULT_FILL &&
-        layer.style.opacity === DEFAULT_OPACITY
-      ) {
-        return '';
-      }
-
-      return `paint: {
-				${withDefault('fill-color', layer.style.fill, DEFAULT_FILL)},
-				${withDefault('fill-opacity', layer.style.opacity, DEFAULT_OPACITY)}
-			}
-			`;
+      return intersperse(
+        [
+          withDefault(
+            'fill-color',
+            layer.style.fill,
+            MAPBOX_DEFAULTS['fill-color']
+          ),
+          withDefault(
+            'fill-opacity',
+            layer.style.opacity,
+            MAPBOX_DEFAULTS['fill-opacity']
+          )
+        ],
+        ',\n'
+      );
     }
     case 'Choropleth': {
-      return `paint: {
-				'fill-color': ${JSON.stringify(deriveColorScale(layer))},
-				${withDefault('fill-opacity', layer.style.opacity, DEFAULT_OPACITY)}
-			}`;
+      return intersperse(
+        [
+          `'fill-color': ${JSON.stringify(deriveColorScale(layer))}`,
+          withDefault(
+            'fill-opacity',
+            layer.style.opacity,
+            MAPBOX_DEFAULTS['fill-opacity']
+          )
+        ],
+        ',\n'
+      );
     }
     case 'Proportional Symbol': {
-      return `paint: {
-				${withDefault('circle-color', layer.style.fill, DEFAULT_FILL)},
-				'circle-radius': ${JSON.stringify(deriveSize(layer))},
-				${withDefault('circle-opacity', layer.style.opacity, DEFAULT_OPACITY)}
-			}`;
+      return intersperse(
+        [
+          withDefault(
+            'circle-color',
+            layer.style.fill,
+            MAPBOX_DEFAULTS['circle-color']
+          ),
+          `'circle-radius': ${JSON.stringify(deriveSize(layer))}`,
+          withDefault(
+            'circle-opacity',
+            layer.style.opacity,
+            MAPBOX_DEFAULTS['fill-opacity']
+          )
+        ],
+        ',\n'
+      );
     }
     case 'Dot Density': {
-      return `paint: {
-				${withDefault('circle-color', layer.style.fill, DEFAULT_FILL)},
-				${withDefault('circle-radius', layer.style.dots.size, DEFAULT_RADIUS)},
-				${withDefault('circle-opacity', layer.style.opacity, DEFAULT_OPACITY)}
-			}`;
+      return intersperse(
+        [
+          withDefault(
+            'circle-color',
+            layer.style.fill,
+            MAPBOX_DEFAULTS['circle-color']
+          ),
+          withDefault(
+            'circle-radius',
+            layer.style.dots.size,
+            MAPBOX_DEFAULTS['circle-radius']
+          ),
+          withDefault(
+            'circle-opacity',
+            layer.style.opacity,
+            MAPBOX_DEFAULTS['circle-opacity']
+          )
+        ],
+        ',\n'
+      );
+    }
+  }
+}
+
+/**
+ * Generate a Mapbox GL JS program fragment representing the layer's stroke.
+ *
+ * @param layer – A CartoKit layer.
+ * @returns – A Mapbox GL JS program fragment representing the layer's stroke.
+ */
+function codegenStroke(layer: CartoKitLayer): string {
+  switch (layer.type) {
+    case 'Fill':
+    case 'Choropleth': {
+      return intersperse(
+        [
+          withDefault(
+            'line-color',
+            layer.style.stroke,
+            MAPBOX_DEFAULTS['line-color']
+          ),
+          withDefault(
+            'line-width',
+            layer.style.strokeWidth,
+            MAPBOX_DEFAULTS['line-width']
+          )
+        ],
+        ',\n'
+      );
+    }
+    case 'Proportional Symbol':
+    case 'Dot Density': {
+      return intersperse(
+        [
+          withDefault(
+            'circle-stroke-color',
+            layer.style.stroke,
+            MAPBOX_DEFAULTS['circle-stroke-color']
+          ),
+          withDefault(
+            'circle-stroke-width',
+            layer.style.strokeWidth,
+            MAPBOX_DEFAULTS['circle-stroke-width']
+          )
+        ],
+        ',\n'
+      );
     }
   }
 }
@@ -75,4 +171,25 @@ function withDefault<T extends string | number>(
         typeof cartokitValue === 'string' ? `'${cartokitValue}'` : cartokitValue
       }`
     : '';
+}
+
+/**
+ * Interperse a set of values by a separator (without leaving a dangling
+ * separator after the last value).
+ *
+ * @param values — The input array of values to separate.
+ * @param sep – A string separator between values.
+ * @returns – A string with values separated by @param sep.
+ */
+function intersperse(values: string[], sep: string): string {
+  const v = values.filter(Boolean);
+
+  switch (v.length) {
+    case 0:
+      return '';
+    case 1:
+      return v[0];
+    default:
+      return v.slice(1).reduce((acc, el) => acc.concat(`${sep}${el}`), v[0]);
+  }
 }

--- a/src/lib/codegen/codegen-paint.ts
+++ b/src/lib/codegen/codegen-paint.ts
@@ -4,32 +4,13 @@ import type { CartoKitLayer } from '$lib/types/CartoKitLayer';
 import { MAPBOX_DEFAULTS } from '$lib/utils/constants';
 
 /**
- * Generate a Mapbox GL JS program fragment representing the layer's paint
- * properties.
- *
- * @param layer – A CartoKit layer.
- *
- * @returns – A Mapbox GL JS program fragment representing the layer's paint
- * properties.
- */
-export function codegenPaint(layer: CartoKitLayer): {
-  fill: string;
-  stroke: string;
-} {
-  return {
-    fill: codegenFill(layer),
-    stroke: codegenStroke(layer)
-  };
-}
-
-/**
  * Generate a Mapbox GL JS program fragment representing the layer's fill.
  *
  * @param layer – A CartoKit layer.
  *
  * @returns – A Mapbox GL JS program fragment representing the layer's fill.
  */
-function codegenFill(layer: CartoKitLayer): string {
+export function codegenFill(layer: CartoKitLayer): string {
   switch (layer.type) {
     case 'Fill': {
       return intersperse(
@@ -110,7 +91,7 @@ function codegenFill(layer: CartoKitLayer): string {
  * @param layer – A CartoKit layer.
  * @returns – A Mapbox GL JS program fragment representing the layer's stroke.
  */
-function codegenStroke(layer: CartoKitLayer): string {
+export function codegenStroke(layer: CartoKitLayer): string {
   switch (layer.type) {
     case 'Fill':
     case 'Choropleth': {

--- a/src/lib/components/color/ColorPicker.svelte
+++ b/src/lib/components/color/ColorPicker.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import * as d3 from 'd3';
 
-  import FieldLabel from '$lib/components/shared/FieldLabel.svelte';
   import HexInput from '$lib/components/color/HexInput.svelte';
   import OpacityInput from '$lib/components/color/OpacityInput.svelte';
+  import FieldLabel from '$lib/components/shared/FieldLabel.svelte';
+  import NumberInput from '$lib/components/shared/NumberInput.svelte';
   import { dispatchLayerUpdate } from '$lib/interaction/update';
   import type {
     CartoKitFillLayer,
@@ -18,26 +19,41 @@
     | CartoKitProportionalSymbolLayer
     | CartoKitDotDensityLayer;
 
-  $: color = d3.color(layer.style.fill)?.formatHex() ?? DEFAULT_FILL;
+  $: fill = d3.color(layer.style.fill)?.formatHex() ?? DEFAULT_FILL;
+  $: stroke = d3.color(layer.style.stroke)?.formatHex() ?? DEFAULT_FILL;
   $: opacity = decimalToPercent(layer.style.opacity);
 
-  function onColorInput(event: Event) {
-    const target = event.target as HTMLInputElement;
-    dispatchLayerUpdate({
-      type: 'fill',
-      layer,
-      payload: {
-        color: target.value
-      }
-    });
+  function onColorInput(property: 'fill' | 'stroke') {
+    return function handleColorInput(event: Event) {
+      const target = event.target as HTMLInputElement;
+      dispatchLayerUpdate({
+        type: property,
+        layer,
+        payload: {
+          color: target.value
+        }
+      });
+    };
   }
 
-  function onHexChange(hex: string) {
+  function onHexChange(property: 'fill' | 'stroke') {
+    return function handleHexChange(hex: string) {
+      dispatchLayerUpdate({
+        type: property,
+        layer,
+        payload: {
+          color: hex
+        }
+      });
+    };
+  }
+
+  function onStrokeWidthChange(event: CustomEvent<{ value: number }>) {
     dispatchLayerUpdate({
-      type: 'fill',
+      type: 'stroke-width',
       layer,
       payload: {
-        color: hex
+        strokeWidth: event.detail.value
       }
     });
   }
@@ -59,10 +75,27 @@
     <input
       type="color"
       class="ml-4 mr-2 h-4 w-4 cursor-pointer appearance-none rounded"
-      value={color}
-      on:input={onColorInput}
+      value={fill}
+      on:input={onColorInput('fill')}
     />
-    <HexInput hex={color} {onHexChange} />
+    <HexInput hex={fill} onHexChange={onHexChange('fill')} />
+  </div>
+  <div class="flex items-center">
+    <FieldLabel fieldId="stroke">Stroke</FieldLabel>
+    <input
+      type="color"
+      class="ml-4 mr-2 h-4 w-4 cursor-pointer appearance-none rounded"
+      value={stroke}
+      on:input={onColorInput('stroke')}
+    />
+    <HexInput hex={stroke} onHexChange={onHexChange('stroke')} />
+  </div>
+  <div class="stack-h stack-h-xs items-center">
+    <FieldLabel fieldId="stroke-width">Stroke Width</FieldLabel>
+    <NumberInput
+      value={layer.style.strokeWidth}
+      on:change={onStrokeWidthChange}
+    />
   </div>
   <OpacityInput {opacity} {onOpacityChange} />
 </div>

--- a/src/lib/components/color/ColorPicker.svelte
+++ b/src/lib/components/color/ColorPicker.svelte
@@ -95,6 +95,7 @@
     <NumberInput
       value={layer.style.strokeWidth}
       on:change={onStrokeWidthChange}
+      class="w-12"
     />
   </div>
   <OpacityInput {opacity} {onOpacityChange} />

--- a/src/lib/components/layers/FromAPI.svelte
+++ b/src/lib/components/layers/FromAPI.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
+  import { getContext } from 'svelte';
+  import type { MapSourceDataEvent } from 'maplibre-gl';
   import * as turf from '@turf/turf';
   import kebabCase from 'lodash.kebabcase';
   import uniqueId from 'lodash.uniqueid';
-  import { getContext } from 'svelte';
 
   import FieldLabel from '$lib/components/shared/FieldLabel.svelte';
   import TextInput from '$lib/components/shared/TextInput.svelte';
@@ -12,7 +13,7 @@
   import { map } from '$lib/stores/map';
   import type { CartoKitFillLayer } from '$lib/types/CartoKitLayer';
   import { randomColor } from '$lib/utils/color';
-  import type { MapSourceDataEvent } from 'maplibre-gl';
+  import { DEFAULT_OPACITY, DEFAULT_STROKE_WIDTH } from '$lib/utils/constants';
 
   const closeModal = getContext<() => void>('close-modal');
 
@@ -41,6 +42,7 @@
   function onSubmit() {
     dataLoading = true;
 
+    const color = randomColor();
     const layer: CartoKitFillLayer = {
       id: uniqueId(kebabCase(displayName)),
       displayName,
@@ -51,8 +53,10 @@
         rawGeoJSON: turf.featureCollection([])
       },
       style: {
-        fill: randomColor(),
-        opacity: 1
+        fill: color,
+        stroke: color,
+        strokeWidth: DEFAULT_STROKE_WIDTH,
+        opacity: DEFAULT_OPACITY
       }
     };
 
@@ -90,7 +94,7 @@
   </div>
   <Button class="self-end">
     {#if dataLoading}
-      <span class="loader" />
+      <span class="loader align-text-top" />
     {:else}
       Add
     {/if}

--- a/src/lib/components/layers/FromFile.svelte
+++ b/src/lib/components/layers/FromFile.svelte
@@ -13,6 +13,7 @@
   import type { CartoKitFillLayer } from '$lib/types/CartoKitLayer';
   import { randomColor } from '$lib/utils/color';
   import { normalizeGeoJSONToFeatureCollection } from '$lib/utils/geojson';
+  import { DEFAULT_OPACITY, DEFAULT_STROKE_WIDTH } from '$lib/utils/constants';
 
   const closeModal = getContext<() => void>('close-modal');
 
@@ -41,6 +42,7 @@
       if (typeof theFile.target?.result === 'string') {
         const geojson = JSON.parse(theFile.target.result);
 
+        const color = randomColor();
         const layer: CartoKitFillLayer = {
           id: uniqueId(kebabCase(displayName)),
           displayName,
@@ -51,8 +53,10 @@
             fileName: file.name
           },
           style: {
-            fill: randomColor(),
-            opacity: 0.75
+            fill: color,
+            stroke: color,
+            strokeWidth: DEFAULT_STROKE_WIDTH,
+            opacity: DEFAULT_OPACITY
           }
         };
 

--- a/src/lib/components/layers/FromFile.svelte
+++ b/src/lib/components/layers/FromFile.svelte
@@ -12,8 +12,8 @@
   import { map } from '$lib/stores/map';
   import type { CartoKitFillLayer } from '$lib/types/CartoKitLayer';
   import { randomColor } from '$lib/utils/color';
-  import { normalizeGeoJSONToFeatureCollection } from '$lib/utils/geojson';
   import { DEFAULT_OPACITY, DEFAULT_STROKE_WIDTH } from '$lib/utils/constants';
+  import { normalizeGeoJSONToFeatureCollection } from '$lib/utils/geojson';
 
   const closeModal = getContext<() => void>('close-modal');
 

--- a/src/lib/interaction/layer.ts
+++ b/src/lib/interaction/layer.ts
@@ -31,6 +31,17 @@ export function addLayer(map: Map, layer: CartoKitLayer): void {
         }
       });
 
+      // Add a separate layer for the stroke.
+      map.addLayer({
+        id: `${layer.id}-stroke`,
+        source: layer.id,
+        type: 'line',
+        paint: {
+          'line-color': layer.style.stroke,
+          'line-width': layer.style.strokeWidth
+        }
+      });
+
       instrumentPolygonHover(map, layer.id);
       instrumentPolygonSelect(map, layer.id);
       break;
@@ -46,6 +57,17 @@ export function addLayer(map: Map, layer: CartoKitLayer): void {
         }
       });
 
+      // Add a separate layer for the stroke.
+      map.addLayer({
+        id: `${layer.id}-stroke`,
+        source: layer.id,
+        type: 'line',
+        paint: {
+          'line-color': layer.style.stroke,
+          'line-width': layer.style.strokeWidth
+        }
+      });
+
       instrumentPolygonHover(map, layer.id);
       instrumentPolygonSelect(map, layer.id);
       break;
@@ -58,7 +80,9 @@ export function addLayer(map: Map, layer: CartoKitLayer): void {
         paint: {
           'circle-color': layer.style.fill,
           'circle-radius': deriveSize(layer),
-          'circle-opacity': layer.style.opacity
+          'circle-opacity': layer.style.opacity,
+          'circle-stroke-color': layer.style.stroke,
+          'circle-stroke-width': layer.style.strokeWidth
         }
       });
 
@@ -96,7 +120,9 @@ export function addLayer(map: Map, layer: CartoKitLayer): void {
         paint: {
           'circle-color': layer.style.fill,
           'circle-radius': layer.style.dots.size,
-          'circle-opacity': layer.style.opacity
+          'circle-opacity': layer.style.opacity,
+          'circle-stroke-color': layer.style.stroke,
+          'circle-stroke-width': layer.style.strokeWidth
         }
       });
 

--- a/src/lib/interaction/map-type.ts
+++ b/src/lib/interaction/map-type.ts
@@ -429,7 +429,8 @@ function transitionToProportionalSymbol(
             min: DEFAULT_MIN_SIZE,
             max: DEFAULT_MAX_SIZE
           },
-          fill: colors[colors.length - 1],
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          fill: colors.at(-1)!,
           stroke: layer.style.stroke,
           strokeWidth: layer.style.strokeWidth,
           opacity: layer.style.opacity
@@ -547,7 +548,8 @@ function transitionToDotDensity(
             size: 1,
             value: dotValue
           },
-          fill: colors[colors.length - 1],
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          fill: colors.at(-1)!,
           stroke: layer.style.stroke,
           strokeWidth: layer.style.strokeWidth,
           opacity: layer.style.opacity

--- a/src/lib/interaction/map-type.ts
+++ b/src/lib/interaction/map-type.ts
@@ -145,7 +145,6 @@ function transitionToFill(
   switch (sourceLayerType) {
     case 'Choropleth': {
       const color = randomColor();
-      const strokeWidth = 1.5;
 
       const targetLayer: CartoKitFillLayer = {
         id: layer.id,
@@ -155,16 +154,15 @@ function transitionToFill(
         style: {
           fill: color,
           stroke: color,
-          strokeWidth: strokeWidth,
+          strokeWidth: layer.style.strokeWidth,
           opacity: layer.style.opacity
         }
       };
 
-      // Just update the fill-color, line-color, and line-width of the existing
-      // layers.
+      // Just update the fill-color and line-color of the existing layer.
+      // All other paint properties should be unchanged.
       map.setPaintProperty(layer.id, 'fill-color', color);
       map.setPaintProperty(`${layer.id}-stroke`, 'line-color', color);
-      map.setPaintProperty(`${layer.id}-stroke`, 'line-width', strokeWidth);
 
       return {
         targetLayer,

--- a/src/lib/interaction/map-type.ts
+++ b/src/lib/interaction/map-type.ts
@@ -144,7 +144,8 @@ function transitionToFill(
 
   switch (sourceLayerType) {
     case 'Choropleth': {
-      const fill = randomColor();
+      const color = randomColor();
+      const strokeWidth = 1.5;
 
       const targetLayer: CartoKitFillLayer = {
         id: layer.id,
@@ -152,13 +153,18 @@ function transitionToFill(
         type: 'Fill',
         data: layer.data,
         style: {
-          fill,
+          fill: color,
+          stroke: color,
+          strokeWidth: strokeWidth,
           opacity: layer.style.opacity
         }
       };
 
-      // Just update the fill-color of the existing layer.
-      map.setPaintProperty(layer.id, 'fill-color', fill);
+      // Just update the fill-color, line-color, and line-width of the existing
+      // layers.
+      map.setPaintProperty(layer.id, 'fill-color', color);
+      map.setPaintProperty(`${layer.id}-stroke`, 'line-color', color);
+      map.setPaintProperty(`${layer.id}-stroke`, 'line-width', strokeWidth);
 
       return {
         targetLayer,
@@ -189,6 +195,8 @@ function transitionToFill(
         },
         style: {
           fill: layer.style.fill,
+          stroke: layer.style.stroke,
+          strokeWidth: layer.style.strokeWidth,
           opacity: layer.style.opacity
         }
       };
@@ -209,6 +217,8 @@ function transitionToFill(
         },
         style: {
           fill: layer.style.fill,
+          stroke: layer.style.stroke,
+          strokeWidth: layer.style.strokeWidth,
           opacity: layer.style.opacity
         }
       };
@@ -261,6 +271,8 @@ function transitionToChoropleth(
               layer.data.geoJSON.features
             )
           },
+          stroke: layer.style.stroke,
+          strokeWidth: layer.style.strokeWidth,
           opacity: layer.style.opacity
         }
       };
@@ -310,6 +322,8 @@ function transitionToChoropleth(
               layer.data.geoJSON.features
             )
           },
+          stroke: layer.style.stroke,
+          strokeWidth: layer.style.strokeWidth,
           opacity: layer.style.opacity
         }
       };
@@ -339,6 +353,8 @@ function transitionToChoropleth(
               layer.data.geoJSON.features
             )
           },
+          stroke: layer.style.stroke,
+          strokeWidth: layer.style.strokeWidth,
           opacity: layer.style.opacity
         }
       };
@@ -387,6 +403,8 @@ function transitionToProportionalSymbol(
             max: DEFAULT_MAX_SIZE
           },
           fill: layer.style.fill,
+          stroke: layer.style.stroke,
+          strokeWidth: layer.style.strokeWidth,
           opacity: layer.style.opacity
         }
       };
@@ -397,6 +415,8 @@ function transitionToProportionalSymbol(
       };
     }
     case 'Choropleth': {
+      const colors = layer.style.breaks.scheme[layer.style.breaks.count];
+
       const targetLayer: CartoKitProportionalSymbolLayer = {
         id: layer.id,
         displayName: layer.displayName,
@@ -411,7 +431,9 @@ function transitionToProportionalSymbol(
             min: DEFAULT_MIN_SIZE,
             max: DEFAULT_MAX_SIZE
           },
-          fill: randomColor(),
+          fill: colors[colors.length - 1],
+          stroke: layer.style.stroke,
+          strokeWidth: layer.style.strokeWidth,
           opacity: layer.style.opacity
         }
       };
@@ -437,6 +459,8 @@ function transitionToProportionalSymbol(
             max: DEFAULT_MAX_SIZE
           },
           fill: layer.style.fill,
+          stroke: layer.style.stroke,
+          strokeWidth: layer.style.strokeWidth,
           opacity: layer.style.opacity
         }
       };
@@ -491,6 +515,8 @@ function transitionToDotDensity(
             value: dotValue
           },
           fill: layer.style.fill,
+          stroke: layer.style.stroke,
+          strokeWidth: layer.style.strokeWidth,
           opacity: layer.style.opacity
         }
       };
@@ -503,6 +529,7 @@ function transitionToDotDensity(
     case 'Choropleth': {
       const features = layer.data.geoJSON.features;
       const dotValue = deriveDotDensityStartingValue(features, layer.attribute);
+      const colors = layer.style.breaks.scheme[layer.style.breaks.count];
 
       const targetLayer: CartoKitDotDensityLayer = {
         id: layer.id,
@@ -522,7 +549,9 @@ function transitionToDotDensity(
             size: 1,
             value: dotValue
           },
-          fill: randomColor(),
+          fill: colors[colors.length - 1],
+          stroke: layer.style.stroke,
+          strokeWidth: layer.style.strokeWidth,
           opacity: layer.style.opacity
         }
       };
@@ -568,6 +597,8 @@ function transitionToDotDensity(
             value: dotValue
           },
           fill: layer.style.fill,
+          stroke: layer.style.stroke,
+          strokeWidth: layer.style.strokeWidth,
           opacity: layer.style.opacity
         }
       };

--- a/src/lib/interaction/update.ts
+++ b/src/lib/interaction/update.ts
@@ -62,6 +62,22 @@ interface FillUpdate extends LayerUpdate {
     | CartoKitDotDensityLayer;
 }
 
+interface StrokeUpdate extends LayerUpdate {
+  type: 'stroke';
+  payload: {
+    color: string;
+  };
+  layer: CartoKitLayer;
+}
+
+interface StrokeWidthUpdate extends LayerUpdate {
+  type: 'stroke-width';
+  payload: {
+    strokeWidth: number;
+  };
+  layer: CartoKitLayer;
+}
+
 interface OpacityUpdate extends LayerUpdate {
   type: 'opacity';
   payload: {
@@ -132,6 +148,8 @@ type DispatchLayerUpdateParams =
   | MapTypeUpdate
   | AttributeUpdate
   | FillUpdate
+  | StrokeUpdate
+  | StrokeWidthUpdate
   | OpacityUpdate
   | ColorScaleUpdate
   | ColorSchemeUpdate
@@ -240,6 +258,62 @@ export function dispatchLayerUpdate({
           case 'Proportional Symbol':
           case 'Dot Density':
             map.setPaintProperty(layer.id, 'circle-color', payload.color);
+            break;
+        }
+
+        return lyrs;
+      });
+      break;
+    }
+    case 'stroke': {
+      layers.update((lyrs) => {
+        const lyr = lyrs[layer.id];
+        lyr.style.stroke = payload.color;
+
+        switch (lyr.type) {
+          case 'Fill':
+          case 'Choropleth':
+            map.setPaintProperty(
+              `${layer.id}-stroke`,
+              'line-color',
+              payload.color
+            );
+            break;
+          case 'Proportional Symbol':
+          case 'Dot Density':
+            map.setPaintProperty(
+              layer.id,
+              'circle-stroke-color',
+              payload.color
+            );
+            break;
+        }
+
+        return lyrs;
+      });
+      break;
+    }
+    case 'stroke-width': {
+      layers.update((lyrs) => {
+        const lyr = lyrs[layer.id];
+        lyr.style.strokeWidth = payload.strokeWidth;
+
+        switch (lyr.type) {
+          case 'Fill':
+          case 'Choropleth':
+            map.setPaintProperty(
+              `${layer.id}-stroke`,
+              'line-width',
+              payload.strokeWidth
+            );
+            break;
+          case 'Proportional Symbol':
+          case 'Dot Density':
+            map.setPaintProperty(
+              layer.id,
+              'circle-stroke-width',
+              payload.strokeWidth
+            );
             break;
         }
 

--- a/src/lib/stores/map-type.ts
+++ b/src/lib/stores/map-type.ts
@@ -3,8 +3,7 @@ import { derived } from 'svelte/store';
 import { selectedFeature } from '$lib/stores/selected-feature';
 import { layers } from '$lib/stores/layers';
 import type { MapType } from '$lib/types/map-types';
-
-const DEFAULT_MAP_TYPE = 'Fill';
+import { DEFAULT_MAP_TYPE } from '$lib/utils/constants';
 
 export const mapType = derived<
   [typeof selectedFeature, typeof layers],

--- a/src/lib/types/CartoKitLayer.ts
+++ b/src/lib/types/CartoKitLayer.ts
@@ -22,6 +22,8 @@ export interface CartoKitFillLayer extends Layer {
   type: 'Fill';
   style: {
     fill: string;
+    stroke: string;
+    strokeWidth: number;
     opacity: number;
   };
 }
@@ -36,6 +38,8 @@ export interface CartoKitChoroplethLayer extends Layer {
       count: number;
       thresholds: number[];
     };
+    stroke: string;
+    strokeWidth: number;
     opacity: number;
   };
 }
@@ -49,6 +53,8 @@ export interface CartoKitProportionalSymbolLayer extends Layer {
       max: number;
     };
     fill: string;
+    stroke: string;
+    strokeWidth: number;
     opacity: number;
   };
 }
@@ -62,6 +68,8 @@ export interface CartoKitDotDensityLayer extends Layer {
       value: number;
     };
     fill: string;
+    stroke: string;
+    strokeWidth: number;
     opacity: number;
   };
 }

--- a/src/lib/utils/constants.ts
+++ b/src/lib/utils/constants.ts
@@ -3,11 +3,12 @@ import type { Feature } from 'geojson';
 
 import { deriveQuantiles } from '$lib/interaction/scales';
 
-export const DEFAULT_OPACITY = 0.75;
+// CartoKit default values.
+export const DEFAULT_MAP_TYPE = 'Fill';
 export const DEFAULT_FILL = '#FFFFFF';
-export const DEFAULT_STROKE = '#FFFFFF';
+export const DEFAULT_STROKE = '#000000';
 export const DEFAULT_STROKE_WIDTH = 1;
-
+export const DEFAULT_OPACITY = 0.75;
 export const DEFAULT_SCALE = 'Quantile';
 export const DEFAULT_SCHEME = d3.schemeOranges;
 export const DEFAULT_COUNT = 5;
@@ -17,9 +18,20 @@ export const DEFAULT_THRESHOLDS = (attribute: string, features: Feature[]) =>
     features,
     range: [...DEFAULT_SCHEME[DEFAULT_COUNT]]
   });
-
 export const DEFAULT_MIN_SIZE = 1;
 export const DEFAULT_MAX_SIZE = 50;
-// MapLibre GL JS's default circle radius.
-// https://maplibre.org/maplibre-gl-js-docs/style-spec/layers/#paint-circle-circle-radius
-export const DEFAULT_RADIUS = 5;
+export const DEFAULT_RADIUS = 2;
+
+// Mapbox default values. Used during codegen to avoid adding stylistic
+// properties that match Mapbox defaults.
+export const MAPBOX_DEFAULTS = {
+  'circle-radius': 5,
+  'fill-color': '#000000',
+  'line-color': '#000000',
+  'fill-opacity': 1,
+  'line-width': 1,
+  'circle-color': '#000000',
+  'circle-opacity': 1,
+  'circle-stroke-color': '#000000',
+  'circle-stroke-width': 0
+};

--- a/src/lib/utils/constants.ts
+++ b/src/lib/utils/constants.ts
@@ -3,8 +3,10 @@ import type { Feature } from 'geojson';
 
 import { deriveQuantiles } from '$lib/interaction/scales';
 
-export const DEFAULT_OPACITY = 1;
+export const DEFAULT_OPACITY = 0.75;
 export const DEFAULT_FILL = '#FFFFFF';
+export const DEFAULT_STROKE = '#FFFFFF';
+export const DEFAULT_STROKE_WIDTH = 1;
 
 export const DEFAULT_SCALE = 'Quantile';
 export const DEFAULT_SCHEME = d3.schemeOranges;

--- a/src/lib/utils/layer.ts
+++ b/src/lib/utils/layer.ts
@@ -8,13 +8,17 @@ import type { CartoKitLayer } from '$lib/types/CartoKitLayer';
  * @returns – an array of instrumented layer ids.
  */
 export function getInstrumetedLayerIds(layer: CartoKitLayer): string[] {
-  if (layer.type === 'Dot Density') {
-    return [
-      `${layer.id}-outlines`,
-      `${layer.id}-outlines-hover`,
-      `${layer.id}-outlines-select`
-    ];
+  switch (layer.type) {
+    case 'Fill':
+    case 'Choropleth':
+      return [`${layer.id}-stroke`, `${layer.id}-hover`, `${layer.id}-select`];
+    case 'Proportional Symbol':
+      return [`${layer.id}-hover`, `${layer.id}-select`];
+    case 'Dot Density':
+      return [
+        `${layer.id}-outlines`,
+        `${layer.id}-outlines-hover`,
+        `${layer.id}-outlines-select`
+      ];
   }
-
-  return [`${layer.id}-hover`, `${layer.id}-select`];
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -80,7 +80,11 @@
           <MenuItem title="Map Type">
             <MapTypeSelect />
           </MenuItem>
-          {#if $selectedLayer.type === 'Choropleth'}
+          {#if $selectedLayer.type === 'Fill'}
+            <MenuItem title="Style">
+              <ColorPicker layer={$selectedLayer} />
+            </MenuItem>
+          {:else if $selectedLayer.type === 'Choropleth'}
             <MenuItem title="Attribute">
               <AttributeSelect layer={$selectedLayer} />
             </MenuItem>
@@ -94,7 +98,7 @@
             <MenuItem title="Size">
               <SizeControls layer={$selectedLayer} />
             </MenuItem>
-            <MenuItem title="Fill">
+            <MenuItem title="Style">
               <ColorPicker layer={$selectedLayer} />
             </MenuItem>
           {:else if $selectedLayer.type === 'Dot Density'}
@@ -104,10 +108,6 @@
             <MenuItem title="Dots">
               <DotControls layer={$selectedLayer} />
             </MenuItem>
-            <MenuItem title="Fill">
-              <ColorPicker layer={$selectedLayer} />
-            </MenuItem>
-          {:else}
             <MenuItem title="Style">
               <ColorPicker layer={$selectedLayer} />
             </MenuItem>


### PR DESCRIPTION
This PR adds support for configurable strokes on `(Multi-)Point` and `(Multi-)Polygon` features.

| Polygon | Point |
| --- | --- |
| <img width="1552" alt="image" src="https://user-images.githubusercontent.com/19421190/236276243-7078f3c3-e760-4546-91da-473eeb5e6241.png"> | <img width="1552" alt="image" src="https://user-images.githubusercontent.com/19421190/236276372-9712199b-a5f7-4a43-ae2b-086215638749.png"> |

Specifically, users can now specify a stroke color and a stroke width. For polygon features, drawing a stroke requires rendering a separate layer of type `line` due to limitations in the `fill-outline` property upstream in MapLibre GL JS and Mapbox GL JS (i.e., we cannot configure a width on `fill-outline`).