### PR TITLE
fix: Rework IR to bind attributes more closely to visual variables.

### DIFF
--- a/src/lib/codegen/codegen-source.ts
+++ b/src/lib/codegen/codegen-source.ts
@@ -118,7 +118,7 @@ function codegenDotDensityTransformation(
   ${fetchData}
 	const dots = ${dataIdent}.features.flatMap((feature) => {
 		const numPoints = Math.floor(
-      feature.properties['${layer.attribute}'] / ${layer.style.dots.value}
+      feature.properties['${layer.style.dots.attribute}'] / ${layer.style.dots.value}
     );
 
 		const bbox = turf.bbox(feature);

--- a/src/lib/components/color/ColorPalette.svelte
+++ b/src/lib/components/color/ColorPalette.svelte
@@ -3,6 +3,7 @@
   import ColorScaleSelect from '$lib/components/color/ColorScaleSelect.svelte';
   import ColorStopsSelect from '$lib/components/color/ColorStopsSelect.svelte';
   import OpacityInput from '$lib/components/color/OpacityInput.svelte';
+  import StrokePicker from '$lib/components/color/StrokePicker.svelte';
   import AttributeSelect from '$lib/components/data/AttributeSelect.svelte';
   import { dispatchLayerUpdate } from '$lib/interaction/update';
   import type { CartoKitChoroplethLayer } from '$lib/types/CartoKitLayer';
@@ -28,5 +29,6 @@
   <ColorScaleSelect {layer} />
   <ColorStopsSelect {layer} />
   <ColorSchemeDropdown {layer} />
+  <StrokePicker {layer} />
   <OpacityInput {opacity} {onOpacityChange} />
 </div>

--- a/src/lib/components/color/ColorPalette.svelte
+++ b/src/lib/components/color/ColorPalette.svelte
@@ -3,6 +3,7 @@
   import ColorScaleSelect from '$lib/components/color/ColorScaleSelect.svelte';
   import ColorStopsSelect from '$lib/components/color/ColorStopsSelect.svelte';
   import OpacityInput from '$lib/components/color/OpacityInput.svelte';
+  import AttributeSelect from '$lib/components/data/AttributeSelect.svelte';
   import { dispatchLayerUpdate } from '$lib/interaction/update';
   import type { CartoKitChoroplethLayer } from '$lib/types/CartoKitLayer';
   import { decimalToPercent } from '$lib/utils/color';
@@ -23,6 +24,7 @@
 </script>
 
 <div class="stack stack-xs">
+  <AttributeSelect {layer} selected={layer.style.fill.attribute} />
   <ColorScaleSelect {layer} />
   <ColorStopsSelect {layer} />
   <ColorSchemeDropdown {layer} />

--- a/src/lib/components/color/ColorPicker.svelte
+++ b/src/lib/components/color/ColorPicker.svelte
@@ -3,6 +3,7 @@
 
   import HexInput from '$lib/components/color/HexInput.svelte';
   import OpacityInput from '$lib/components/color/OpacityInput.svelte';
+  import StrokePicker from '$lib/components/color/StrokePicker.svelte';
   import FieldLabel from '$lib/components/shared/FieldLabel.svelte';
   import NumberInput from '$lib/components/shared/NumberInput.svelte';
   import { dispatchLayerUpdate } from '$lib/interaction/update';
@@ -20,40 +21,25 @@
     | CartoKitDotDensityLayer;
 
   $: fill = d3.color(layer.style.fill)?.formatHex() ?? DEFAULT_FILL;
-  $: stroke = d3.color(layer.style.stroke)?.formatHex() ?? DEFAULT_FILL;
   $: opacity = decimalToPercent(layer.style.opacity);
 
-  function onColorInput(property: 'fill' | 'stroke') {
-    return function handleColorInput(event: Event) {
-      const target = event.target as HTMLInputElement;
-      dispatchLayerUpdate({
-        type: property,
-        layer,
-        payload: {
-          color: target.value
-        }
-      });
-    };
-  }
-
-  function onHexChange(property: 'fill' | 'stroke') {
-    return function handleHexChange(hex: string) {
-      dispatchLayerUpdate({
-        type: property,
-        layer,
-        payload: {
-          color: hex
-        }
-      });
-    };
-  }
-
-  function onStrokeWidthChange(event: CustomEvent<{ value: number }>) {
+  function onFillInput(event: Event) {
+    const target = event.target as HTMLInputElement;
     dispatchLayerUpdate({
-      type: 'stroke-width',
+      type: 'fill',
       layer,
       payload: {
-        strokeWidth: event.detail.value
+        color: target.value
+      }
+    });
+  }
+
+  function onFillHexChange(hex: string) {
+    dispatchLayerUpdate({
+      type: 'fill',
+      layer,
+      payload: {
+        color: hex
       }
     });
   }
@@ -76,27 +62,10 @@
       type="color"
       class="ml-4 mr-2 h-4 w-4 cursor-pointer appearance-none rounded"
       value={fill}
-      on:input={onColorInput('fill')}
+      on:input={onFillInput}
     />
-    <HexInput hex={fill} onHexChange={onHexChange('fill')} />
+    <HexInput hex={fill} onHexChange={onFillHexChange} />
   </div>
-  <div class="flex items-center">
-    <FieldLabel fieldId="stroke">Stroke</FieldLabel>
-    <input
-      type="color"
-      class="ml-4 mr-2 h-4 w-4 cursor-pointer appearance-none rounded"
-      value={stroke}
-      on:input={onColorInput('stroke')}
-    />
-    <HexInput hex={stroke} onHexChange={onHexChange('stroke')} />
-  </div>
-  <div class="stack-h stack-h-xs items-center">
-    <FieldLabel fieldId="stroke-width">Stroke Width</FieldLabel>
-    <NumberInput
-      value={layer.style.strokeWidth}
-      on:change={onStrokeWidthChange}
-      class="w-12"
-    />
-  </div>
+  <StrokePicker {layer} />
   <OpacityInput {opacity} {onOpacityChange} />
 </div>

--- a/src/lib/components/color/ColorScaleSelect.svelte
+++ b/src/lib/components/color/ColorScaleSelect.svelte
@@ -22,7 +22,7 @@
     toJSON: () => {}
   };
 
-  $: selected = layer.style.breaks.scale;
+  $: selected = layer.style.fill.scale;
   const options = COLOR_SCALES.map((scale) => ({
     value: scale,
     label: scale

--- a/src/lib/components/color/ColorSchemeDropdown.svelte
+++ b/src/lib/components/color/ColorSchemeDropdown.svelte
@@ -8,8 +8,8 @@
 
   export let layer: CartoKitChoroplethLayer;
 
-  $: count = layer.style.breaks.count;
-  $: colors = layer.style.breaks.scheme[count];
+  $: count = layer.style.fill.count;
+  $: colors = layer.style.fill.scheme[count];
 
   let showDropdown = false;
   let offsetHeight = 0;

--- a/src/lib/components/color/ColorStopsSelect.svelte
+++ b/src/lib/components/color/ColorStopsSelect.svelte
@@ -25,7 +25,7 @@
 
 <Select
   {options}
-  selected={layer.style.breaks.count}
+  selected={layer.style.fill.count}
   on:change={onChange}
   title="Steps"
 />

--- a/src/lib/components/color/ManualBreaks.svelte
+++ b/src/lib/components/color/ManualBreaks.svelte
@@ -10,7 +10,7 @@
   export let toggleBreaksEditorVisibility: () => void;
 
   $: count = layer.style.fill.count;
-  $: colors = layer.style.fill.scheme[count] as string[];
+  $: colors = layer.style.fill.scheme[count];
   $: [min, max] = deriveExtent(
     layer.style.fill.attribute,
     layer.data.geoJSON.features

--- a/src/lib/components/color/ManualBreaks.svelte
+++ b/src/lib/components/color/ManualBreaks.svelte
@@ -9,10 +9,13 @@
   export let layer: CartoKitChoroplethLayer;
   export let toggleBreaksEditorVisibility: () => void;
 
-  $: count = layer.style.breaks.count;
-  $: colors = layer.style.breaks.scheme[count] as string[];
-  $: [min, max] = deriveExtent(layer.attribute, layer.data.geoJSON.features);
-  $: thresholds = layer.style.breaks.thresholds;
+  $: count = layer.style.fill.count;
+  $: colors = layer.style.fill.scheme[count] as string[];
+  $: [min, max] = deriveExtent(
+    layer.style.fill.attribute,
+    layer.data.geoJSON.features
+  );
+  $: thresholds = layer.style.fill.thresholds;
 
   function onThresholdChange(i: number) {
     return function handleThresholdChange(

--- a/src/lib/components/color/StrokePicker.svelte
+++ b/src/lib/components/color/StrokePicker.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+  import * as d3 from 'd3';
+
+  import HexInput from '$lib/components/color/HexInput.svelte';
+  import FieldLabel from '$lib/components/shared/FieldLabel.svelte';
+  import NumberInput from '$lib/components/shared/NumberInput.svelte';
+  import { dispatchLayerUpdate } from '$lib/interaction/update';
+  import type { CartoKitLayer } from '$lib/types/CartoKitLayer';
+  import { DEFAULT_STROKE } from '$lib/utils/constants';
+
+  export let layer: CartoKitLayer;
+
+  $: stroke = d3.color(layer.style.stroke)?.formatHex() ?? DEFAULT_STROKE;
+
+  function onStrokeInput(event: Event) {
+    const target = event.target as HTMLInputElement;
+    dispatchLayerUpdate({
+      type: 'stroke',
+      layer,
+      payload: {
+        color: target.value
+      }
+    });
+  }
+
+  function onStrokeHexChange(hex: string) {
+    dispatchLayerUpdate({
+      type: 'stroke',
+      layer,
+      payload: {
+        color: hex
+      }
+    });
+  }
+
+  function onStrokeWidthChange(event: CustomEvent<{ value: number }>) {
+    dispatchLayerUpdate({
+      type: 'stroke-width',
+      layer,
+      payload: {
+        strokeWidth: event.detail.value
+      }
+    });
+  }
+</script>
+
+<div class="color-picker flex items-center">
+  <FieldLabel fieldId="stroke">Stroke</FieldLabel>
+  <input
+    type="color"
+    class="ml-4 mr-2 h-4 w-4 cursor-pointer appearance-none rounded"
+    value={stroke}
+    on:input={onStrokeInput}
+  />
+  <HexInput hex={stroke} onHexChange={onStrokeHexChange} />
+</div>
+<div class="stack-h stack-h-xs items-center">
+  <FieldLabel fieldId="stroke-width">Stroke Width</FieldLabel>
+  <NumberInput
+    value={layer.style.strokeWidth}
+    on:change={onStrokeWidthChange}
+    class="w-12"
+  />
+</div>

--- a/src/lib/components/data/AttributeSelect.svelte
+++ b/src/lib/components/data/AttributeSelect.svelte
@@ -7,8 +7,8 @@
     CartoKitProportionalSymbolLayer,
     CartoKitDotDensityLayer
   } from '$lib/types/CartoKitLayer';
-  import { selectNumericAttribute } from '$lib/utils/geojson';
 
+  export let selected: string;
   export let layer:
     | CartoKitChoroplethLayer
     | CartoKitProportionalSymbolLayer
@@ -20,8 +20,6 @@
       label: attribute
     })
   );
-  $: selected =
-    layer.attribute || selectNumericAttribute(layer.data.geoJSON.features);
 
   function onChange(event: CustomEvent<{ value: string }>) {
     const attribute = event.detail.value;
@@ -35,4 +33,6 @@
   }
 </script>
 
-<Select {options} {selected} on:change={onChange} />
+<div class="stack-h stack-h-xs items-center">
+  <Select {options} {selected} on:change={onChange} title="Attribute" />
+</div>

--- a/src/lib/components/dots/DotControls.svelte
+++ b/src/lib/components/dots/DotControls.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import AttributeSelect from '$lib/components/data/AttributeSelect.svelte';
   import FieldLabel from '$lib/components/shared/FieldLabel.svelte';
   import NumberInput from '$lib/components/shared/NumberInput.svelte';
   import { dispatchLayerUpdate } from '$lib/interaction/update';
@@ -31,6 +32,7 @@
 </script>
 
 <div class="stack stack-xs">
+  <AttributeSelect {layer} selected={layer.style.dots.attribute} />
   <div class="stack-h stack-h-xs items-center">
     <FieldLabel fieldId="Dot Size">Dot Size</FieldLabel>
     <NumberInput

--- a/src/lib/components/legends/ChoroplethLegend.svelte
+++ b/src/lib/components/legends/ChoroplethLegend.svelte
@@ -5,24 +5,27 @@
   export let layer: CartoKitChoroplethLayer;
   let stops: number[] = [];
 
-  $: count = layer.style.breaks.count;
+  $: count = layer.style.fill.count;
   // This cast allows the calls to deriveQuantiles, dervieEqulaIntervals,
-  // and deriveJenksBreaks to type check. The type of layer.style.breaks.scheme[count]
+  // and deriveJenksBreaks to type check. The type of layer.style.fill.scheme[count]
   // is readonly string[]. These functions do not mutate the array in any way.
-  $: colors = layer.style.breaks.scheme[count] as string[];
+  $: colors = layer.style.fill.scheme[count] as string[];
 
-  $: [min, max] = deriveExtent(layer.attribute, layer.data.geoJSON.features);
+  $: [min, max] = deriveExtent(
+    layer.style.fill.attribute,
+    layer.data.geoJSON.features
+  );
   $: stops = deriveThresholds({
-    scale: layer.style.breaks.scale,
+    scale: layer.style.fill.scale,
     layer,
-    attribute: layer.attribute,
+    attribute: layer.style.fill.attribute,
     features: layer.data.geoJSON.features,
     range: colors
   });
 </script>
 
 <div class="stack stack-xs ml-8 text-white">
-  <p>{layer.attribute}</p>
+  <p>{layer.style.fill.attribute}</p>
   <div class="stack-h stack-h-xs rounded-md bg-slate-900">
     <ul class="stack stack-xs items-end">
       {#each [min, ...stops, max] as stop}

--- a/src/lib/components/legends/DotDensityLegend.svelte
+++ b/src/lib/components/legends/DotDensityLegend.svelte
@@ -5,7 +5,7 @@
 </script>
 
 <div class="stack stack-xs ml-8">
-  <span>{layer.attribute}</span>
+  <span>{layer.style.dots.attribute}</span>
   <div class="stack-h stack-h-xs items-center">
     <svg
       viewBox="0 0 {layer.style.dots.size * 2} {layer.style.dots.size * 2}"

--- a/src/lib/components/legends/ProportionalSymbolLegend.svelte
+++ b/src/lib/components/legends/ProportionalSymbolLegend.svelte
@@ -8,7 +8,10 @@
 
   $: sizeMin = layer.style.size.min;
   $: sizeMax = layer.style.size.max;
-  $: [min, max] = deriveExtent(layer.attribute, layer.data.geoJSON.features);
+  $: [min, max] = deriveExtent(
+    layer.style.size.attribute,
+    layer.data.geoJSON.features
+  );
 
   const padding = { top: 4, right: 4, bottom: 4, left: 4 };
   // Dynamically compute the label width based on the max value.
@@ -27,7 +30,7 @@
 <div class="stack stack-xs ml-8">
   <span
     style="margin-left: {sizeMax * 2 + padding.left * 2 + padding.right * 2}px;"
-    >{layer.attribute}</span
+    >{layer.style.size.attribute}</span
   >
   <svg
     viewBox="0 0 {sizeMax * 2 +

--- a/src/lib/components/size/SizeControls.svelte
+++ b/src/lib/components/size/SizeControls.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import AttributeSelect from '$lib/components/data/AttributeSelect.svelte';
   import FieldLabel from '$lib/components/shared/FieldLabel.svelte';
   import NumberInput from '$lib/components/shared/NumberInput.svelte';
   import { dispatchLayerUpdate } from '$lib/interaction/update';
@@ -22,6 +23,7 @@
 </script>
 
 <div class="stack stack-xs">
+  <AttributeSelect {layer} selected={layer.style.size.attribute} />
   <div class="stack-h stack-h-xs items-center">
     <FieldLabel fieldId="Min">Min</FieldLabel>
     <NumberInput min={1} value={min} on:change={onSizeChange('min')} />

--- a/src/lib/interaction/color.ts
+++ b/src/lib/interaction/color.ts
@@ -14,7 +14,7 @@ export function deriveColorScale(
 ): ExpressionSpecification {
   const {
     style: {
-      breaks: { scheme, count, thresholds }
+      fill: { scheme, count, thresholds }
     }
   } = layer;
 
@@ -22,7 +22,7 @@ export function deriveColorScale(
 
   const prelude: ExpressionSpecification = [
     'step',
-    ['get', layer.attribute],
+    ['get', layer.style.fill.attribute],
     colors[0]
   ];
   const stops = colors.reduce<(string | number)[]>(

--- a/src/lib/interaction/geometry.ts
+++ b/src/lib/interaction/geometry.ts
@@ -16,12 +16,11 @@ export function deriveSize(
   layer: CartoKitProportionalSymbolLayer
 ): ExpressionSpecification {
   const {
-    attribute,
     data: {
       geoJSON: { features }
     },
     style: {
-      size: { min: rMin, max: rMax }
+      size: { attribute, min: rMin, max: rMax }
     }
   } = layer;
   const extent = d3.extent(features, (d) =>

--- a/src/lib/interaction/map-type.ts
+++ b/src/lib/interaction/map-type.ts
@@ -258,9 +258,9 @@ function transitionToChoropleth(
         displayName: layer.displayName,
         type: 'Choropleth',
         data: layer.data,
-        attribute,
         style: {
-          breaks: {
+          fill: {
+            attribute,
             scale: DEFAULT_SCALE,
             scheme: DEFAULT_SCHEME,
             count: DEFAULT_COUNT,
@@ -309,14 +309,14 @@ function transitionToChoropleth(
           ...layer.data,
           geoJSON: layer.data.rawGeoJSON
         },
-        attribute: layer.attribute,
         style: {
-          breaks: {
+          fill: {
+            attribute: layer.style.size.attribute,
             scale: DEFAULT_SCALE,
             scheme: DEFAULT_SCHEME,
             count: DEFAULT_COUNT,
             thresholds: DEFAULT_THRESHOLDS(
-              layer.attribute,
+              layer.style.size.attribute,
               layer.data.geoJSON.features
             )
           },
@@ -340,14 +340,14 @@ function transitionToChoropleth(
           ...layer.data,
           geoJSON: layer.data.rawGeoJSON
         },
-        attribute: layer.attribute,
         style: {
-          breaks: {
+          fill: {
+            attribute: layer.style.dots.attribute,
             scale: DEFAULT_SCALE,
             scheme: DEFAULT_SCHEME,
             count: DEFAULT_COUNT,
             thresholds: DEFAULT_THRESHOLDS(
-              layer.attribute,
+              layer.style.dots.attribute,
               layer.data.geoJSON.features
             )
           },
@@ -394,9 +394,9 @@ function transitionToProportionalSymbol(
           ...layer.data,
           geoJSON: deriveCentroids(features)
         },
-        attribute: selectNumericAttribute(features),
         style: {
           size: {
+            attribute: selectNumericAttribute(features),
             min: DEFAULT_MIN_SIZE,
             max: DEFAULT_MAX_SIZE
           },
@@ -413,7 +413,7 @@ function transitionToProportionalSymbol(
       };
     }
     case 'Choropleth': {
-      const colors = layer.style.breaks.scheme[layer.style.breaks.count];
+      const colors = layer.style.fill.scheme[layer.style.fill.count];
 
       const targetLayer: CartoKitProportionalSymbolLayer = {
         id: layer.id,
@@ -423,9 +423,9 @@ function transitionToProportionalSymbol(
           ...layer.data,
           geoJSON: deriveCentroids(features)
         },
-        attribute: layer.attribute,
         style: {
           size: {
+            attribute: layer.style.fill.attribute,
             min: DEFAULT_MIN_SIZE,
             max: DEFAULT_MAX_SIZE
           },
@@ -451,9 +451,9 @@ function transitionToProportionalSymbol(
           ...layer.data,
           geoJSON: deriveCentroids(layer.data.rawGeoJSON.features)
         },
-        attribute: layer.attribute,
         style: {
           size: {
+            attribute: layer.style.dots.attribute,
             min: DEFAULT_MIN_SIZE,
             max: DEFAULT_MAX_SIZE
           },
@@ -499,7 +499,6 @@ function transitionToDotDensity(
         id: layer.id,
         displayName: layer.displayName,
         type: 'Dot Density',
-        attribute,
         data: {
           ...layer.data,
           geoJSON: generateDotDensityPoints({
@@ -510,6 +509,7 @@ function transitionToDotDensity(
         },
         style: {
           dots: {
+            attribute,
             size: 1,
             value: dotValue
           },
@@ -527,24 +527,27 @@ function transitionToDotDensity(
     }
     case 'Choropleth': {
       const features = layer.data.geoJSON.features;
-      const dotValue = deriveDotDensityStartingValue(features, layer.attribute);
-      const colors = layer.style.breaks.scheme[layer.style.breaks.count];
+      const colors = layer.style.fill.scheme[layer.style.fill.count];
+      const dotValue = deriveDotDensityStartingValue(
+        features,
+        layer.style.fill.attribute
+      );
 
       const targetLayer: CartoKitDotDensityLayer = {
         id: layer.id,
         displayName: layer.displayName,
         type: 'Dot Density',
-        attribute: layer.attribute,
         data: {
           ...layer.data,
           geoJSON: generateDotDensityPoints({
             features,
-            attribute: layer.attribute,
+            attribute: layer.style.fill.attribute,
             value: dotValue
           })
         },
         style: {
           dots: {
+            attribute: layer.style.fill.attribute,
             size: 1,
             value: dotValue
           },
@@ -576,23 +579,26 @@ function transitionToDotDensity(
       }
 
       const features = layer.data.rawGeoJSON.features;
-      const dotValue = deriveDotDensityStartingValue(features, layer.attribute);
+      const dotValue = deriveDotDensityStartingValue(
+        features,
+        layer.style.size.attribute
+      );
 
       const targetLayer: CartoKitDotDensityLayer = {
         id: layer.id,
         displayName: layer.displayName,
         type: 'Dot Density',
-        attribute: layer.attribute,
         data: {
           ...layer.data,
           geoJSON: generateDotDensityPoints({
             features,
-            attribute: layer.attribute,
+            attribute: layer.style.size.attribute,
             value: dotValue
           })
         },
         style: {
           dots: {
+            attribute: layer.style.size.attribute,
             size: 1,
             value: dotValue
           },

--- a/src/lib/interaction/scales.ts
+++ b/src/lib/interaction/scales.ts
@@ -152,6 +152,6 @@ export function deriveThresholds({
     case 'Jenks':
       return deriveJenksBreaks({ attribute, features, range });
     case 'Manual':
-      return layer.style.breaks.thresholds;
+      return layer.style.fill.thresholds;
   }
 }

--- a/src/lib/interaction/update.ts
+++ b/src/lib/interaction/update.ts
@@ -209,16 +209,18 @@ export function dispatchLayerUpdate({
           | CartoKitChoroplethLayer
           | CartoKitProportionalSymbolLayer
           | CartoKitDotDensityLayer;
-        lyr.attribute = payload.attribute;
 
         switch (lyr.type) {
           case 'Choropleth':
+            lyr.style.fill.attribute = payload.attribute;
             map.setPaintProperty(lyr.id, 'fill-color', deriveColorScale(lyr));
             break;
           case 'Proportional Symbol':
+            lyr.style.size.attribute = payload.attribute;
             map.setPaintProperty(lyr.id, 'circle-radius', deriveSize(lyr));
             break;
           case 'Dot Density': {
+            lyr.style.dots.attribute = payload.attribute;
             const dotValue = deriveDotDensityStartingValue(
               lyr.data.rawGeoJSON.features,
               payload.attribute
@@ -347,13 +349,13 @@ export function dispatchLayerUpdate({
         // this update. Therefore, accessing that same layer in the store by id
         // guarantees that lyr is also a CartoKitChoroplethLayer.
         const lyr = lyrs[layer.id] as CartoKitChoroplethLayer;
-        lyr.style.breaks.scale = payload.scale;
-        lyr.style.breaks.thresholds = deriveThresholds({
+        lyr.style.fill.scale = payload.scale;
+        lyr.style.fill.thresholds = deriveThresholds({
           scale: payload.scale,
           layer: lyr,
-          attribute: lyr.attribute,
+          attribute: lyr.style.fill.attribute,
           features: lyr.data.geoJSON.features,
-          range: [...lyr.style.breaks.scheme[lyr.style.breaks.count]]
+          range: [...lyr.style.fill.scheme[lyr.style.fill.count]]
         });
 
         map.setPaintProperty(lyr.id, 'fill-color', deriveColorScale(lyr));
@@ -365,7 +367,7 @@ export function dispatchLayerUpdate({
     case 'color-scheme': {
       layers.update((lyrs) => {
         const lyr = lyrs[layer.id] as CartoKitChoroplethLayer;
-        lyr.style.breaks.scheme = payload.scheme;
+        lyr.style.fill.scheme = payload.scheme;
 
         map.setPaintProperty(lyr.id, 'fill-color', deriveColorScale(lyr));
 
@@ -376,13 +378,13 @@ export function dispatchLayerUpdate({
     case 'color-count': {
       layers.update((lyrs) => {
         const lyr = lyrs[layer.id] as CartoKitChoroplethLayer;
-        lyr.style.breaks.count = payload.count;
-        lyr.style.breaks.thresholds = deriveThresholds({
-          scale: lyr.style.breaks.scale,
+        lyr.style.fill.count = payload.count;
+        lyr.style.fill.thresholds = deriveThresholds({
+          scale: lyr.style.fill.scale,
           layer: lyr,
-          attribute: lyr.attribute,
+          attribute: lyr.style.fill.attribute,
           features: lyr.data.geoJSON.features,
-          range: [...lyr.style.breaks.scheme[payload.count]]
+          range: [...lyr.style.fill.scheme[payload.count]]
         });
 
         map.setPaintProperty(lyr.id, 'fill-color', deriveColorScale(lyr));
@@ -394,7 +396,7 @@ export function dispatchLayerUpdate({
     case 'color-threshold': {
       layers.update((lyrs) => {
         const lyr = lyrs[layer.id] as CartoKitChoroplethLayer;
-        lyr.style.breaks.thresholds[payload.index] = payload.threshold;
+        lyr.style.fill.thresholds[payload.index] = payload.threshold;
 
         map.setPaintProperty(lyr.id, 'fill-color', deriveColorScale(lyr));
 
@@ -436,7 +438,7 @@ export function dispatchLayerUpdate({
         // allow us to generate a dot density.
         const features = generateDotDensityPoints({
           features: lyr.data.rawGeoJSON.features,
-          attribute: lyr.attribute,
+          attribute: lyr.style.dots.attribute,
           value: payload.value
         });
 

--- a/src/lib/types/CartoKitLayer.ts
+++ b/src/lib/types/CartoKitLayer.ts
@@ -30,9 +30,9 @@ export interface CartoKitFillLayer extends Layer {
 
 export interface CartoKitChoroplethLayer extends Layer {
   type: 'Choropleth';
-  attribute: string;
   style: {
-    breaks: {
+    fill: {
+      attribute: string;
       scale: ColorScale;
       scheme: ColorScheme;
       count: number;
@@ -46,9 +46,9 @@ export interface CartoKitChoroplethLayer extends Layer {
 
 export interface CartoKitProportionalSymbolLayer extends Layer {
   type: 'Proportional Symbol';
-  attribute: string;
   style: {
     size: {
+      attribute: string;
       min: number;
       max: number;
     };
@@ -61,9 +61,9 @@ export interface CartoKitProportionalSymbolLayer extends Layer {
 
 export interface CartoKitDotDensityLayer extends Layer {
   type: 'Dot Density';
-  attribute: string;
   style: {
     dots: {
+      attribute: string;
       size: number;
       value: number;
     };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -85,16 +85,10 @@
               <ColorPicker layer={$selectedLayer} />
             </MenuItem>
           {:else if $selectedLayer.type === 'Choropleth'}
-            <MenuItem title="Attribute">
-              <AttributeSelect layer={$selectedLayer} />
-            </MenuItem>
             <MenuItem title="Palette">
               <ColorPalette layer={$selectedLayer} />
             </MenuItem>
           {:else if $selectedLayer.type === 'Proportional Symbol'}
-            <MenuItem title="Attribute">
-              <AttributeSelect layer={$selectedLayer} />
-            </MenuItem>
             <MenuItem title="Size">
               <SizeControls layer={$selectedLayer} />
             </MenuItem>
@@ -102,9 +96,6 @@
               <ColorPicker layer={$selectedLayer} />
             </MenuItem>
           {:else if $selectedLayer.type === 'Dot Density'}
-            <MenuItem title="Attribute">
-              <AttributeSelect layer={$selectedLayer} />
-            </MenuItem>
             <MenuItem title="Dots">
               <DotControls layer={$selectedLayer} />
             </MenuItem>


### PR DESCRIPTION
This PR reorganizes the `cartokit` IR to align with our [latest spec](https://plait-lab.notion.site/cartokit-IR-f46e62d4446a4839a7f4b54907946826). The central idea here is to open up space for future extensions to the IR where a layer can map multiple attributes to multiple visual variables. For example, we may want to allow users to map a numeric attribute to circle size in a Proportional Symbol map while also allowing them to map a categorical attribute to a fill. While many of these visualizations would be achievable today by uploading the same dataset multiple times and rendering them as separate layers, we don't necessarily want users to have to go that route. In short, the goal with this PR is to support a world where layers can map multiple visual variables at once concisely!