### PR TITLE
Begin work on #27. Add support for live preview to data transformation interface.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@codemirror/lang-javascript": "^6.1.5",
+    "@codemirror/lang-json": "^6.0.1",
     "@turf/bbox": "^6.5.0",
     "@turf/boolean-within": "^6.5.0",
     "@turf/centroid": "^6.5.0",

--- a/src/app.css
+++ b/src/app.css
@@ -2,25 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-/* CodeMirror */
-.cm-editor {
-  @apply h-full;
-}
-
-.cm-editor .cm-scroller {
-  @apply font-mono text-xs;
-}
-
-/* Basemap Inset */
-[id^='inset'] .maplibregl-ctrl-bottom-right {
-  display: none;
-}
-
-[id^='inset'] .maplibregl-canvas-container.maplibregl-interactive {
-  cursor: pointer;
-}
-
-/* Utilities */
 @layer utilities {
   /* Block Stack */
   .stack {
@@ -143,4 +124,30 @@
   .hex-input:focus-within > input:first-child {
     @apply border-slate-600;
   }
+
+  .transformation-editor .cm-editor {
+    max-height: 148px;
+  }
+}
+
+/*************
+ * Overrides *
+ *************/
+
+/* CodeMirror */
+.cm-editor {
+  @apply h-full;
+}
+
+.cm-editor .cm-scroller {
+  @apply font-mono text-xs;
+}
+
+/* Basemap Inset */
+[id^='inset'] .maplibregl-ctrl-bottom-right {
+  display: none;
+}
+
+[id^='inset'] .maplibregl-canvas-container.maplibregl-interactive {
+  cursor: pointer;
 }

--- a/src/lib/components/data/AttributeEditor.svelte
+++ b/src/lib/components/data/AttributeEditor.svelte
@@ -4,6 +4,7 @@
   import { javascript } from '@codemirror/lang-javascript';
   import { json } from '@codemirror/lang-json';
 
+  import TransformationAlert from '$lib/components/data/TransformationAlert.svelte';
   import CloseIcon from '$lib/components/icons/CloseIcon.svelte';
   import PlayCircle from '$lib/components/icons/PlayCircle.svelte';
   import Button from '$lib/components/shared/Button.svelte';
@@ -17,7 +18,6 @@
     CartoKitProportionalSymbolLayer
   } from '$lib/types/CartoKitLayer';
   import { transformationWorker } from '$lib/utils/worker';
-  import TransformationAlert from './TransformationAlert.svelte';
 
   export let onClose: () => void;
   export let layer:

--- a/src/lib/components/data/AttributeEditor.svelte
+++ b/src/lib/components/data/AttributeEditor.svelte
@@ -3,6 +3,7 @@
   import { slide } from 'svelte/transition';
   import { basicSetup, EditorView } from 'codemirror';
   import { javascript } from '@codemirror/lang-javascript';
+  import { json } from '@codemirror/lang-json';
 
   import AlertIcon from '$lib/components/icons/AlertIcon.svelte';
   import CheckIcon from '$lib/components/icons/CheckIcon.svelte';
@@ -12,6 +13,7 @@
   import Menu from '$lib/components/shared/Menu.svelte';
   import MenuItem from '$lib/components/shared/MenuItem.svelte';
   import { dispatchLayerUpdate } from '$lib/interaction/update';
+  import { selectedFeature } from '$lib/stores/selected-feature';
   import type {
     CartoKitChoroplethLayer,
     CartoKitDotDensityLayer,
@@ -25,30 +27,57 @@
     | CartoKitProportionalSymbolLayer
     | CartoKitDotDensityLayer;
 
+  // Main editor state.
   let editor: HTMLDivElement;
   let view: EditorView;
   let error: string = '';
   let success: boolean = false;
+
+  // Preview editor state.
+  let editorPreview: HTMLDivElement;
+  let preview: EditorView;
+  let previewError: string = '';
+  let previewDoc: string = JSON.stringify(
+    {
+      type: $selectedFeature?.type,
+      properties: $selectedFeature?.properties,
+      geometry: $selectedFeature?.geometry
+    },
+    null,
+    2
+  );
   let timeoutId: number | undefined;
 
   export function focus() {
     view.focus();
   }
-
-  const doc = `function transformFeatures(features) {
-  return features;
-}`;
-
   onMount(() => {
     view = new EditorView({
-      doc,
-      extensions: [basicSetup, javascript()],
+      doc: `function transformFeatures(features) {
+  return features;
+}`,
+      extensions: [
+        basicSetup,
+        javascript(),
+        EditorView.updateListener.of((v) => {
+          if (v.docChanged) {
+            onChange();
+          }
+        })
+      ],
       parent: editor
+    });
+
+    preview = new EditorView({
+      doc: previewDoc,
+      extensions: [basicSetup, json(), EditorView.editable.of(false)],
+      parent: editorPreview
     });
   });
 
   function onClick() {
     const program = view.state.doc.toString();
+
     transformationWorker(program, layer.data.geoJSON.features, (message) => {
       if (message.type === 'data') {
         dispatchLayerUpdate({
@@ -74,13 +103,49 @@
     });
   }
 
+  function onChange() {
+    const program = view.state.doc.toString();
+
+    if ($selectedFeature) {
+      transformationWorker(program, [$selectedFeature], (message) => {
+        if (message.type === 'data' && message.data?.[0]) {
+          previewError = '';
+
+          previewDoc = JSON.stringify(
+            {
+              type: message.data[0].type,
+              properties: message.data[0].properties,
+              geometry: message.data[0].geometry
+            },
+            null,
+            2
+          );
+        } else if (message.type === 'data') {
+          previewError = '';
+
+          previewDoc = JSON.stringify(message.data?.[0], null, 2);
+        } else {
+          previewDoc = '';
+          previewError = message.error.message;
+        }
+      });
+    }
+  }
+
   onDestroy(() => {
     view.destroy();
+    preview.destroy();
 
     if (timeoutId) {
       window.clearTimeout(timeoutId);
     }
   });
+
+  $: if (preview) {
+    preview.dispatch({
+      changes: { from: 0, to: preview.state.doc.length, insert: previewDoc }
+    });
+  }
 </script>
 
 <Menu class="w-96">
@@ -90,7 +155,10 @@
       <p class="font-sans">
         Use the editor below to transform your dataset using JavaScript.
       </p>
-      <div bind:this={editor} class="-mx-4 overflow-auto bg-white text-black" />
+      <div
+        bind:this={editor}
+        class="transformation-editor -mx-4 overflow-auto bg-white text-black"
+      />
       {#if error}
         <div class="stack stack-xs" transition:slide>
           <div
@@ -123,5 +191,25 @@
         on:click={onClick}><span>Run</span><PlayCircle /></Button
       >
     </div>
+  </MenuItem>
+  <MenuItem title="Preview (1 selected feature)" titleClass="items-baseline">
+    <div
+      class="transformation-editor relative -mx-4 overflow-auto bg-white text-black"
+      bind:this={editorPreview}
+    />
+    <p slot="action" class="text-slate-400">OUTPUT</p>
+    {#if previewError}
+      <div
+        class="stack stack-xs rounded border border-red-400 bg-red-400 bg-opacity-50 px-2 py-1"
+      >
+        <div class="stack-h stack-h-xs items-center">
+          <AlertIcon />
+          <p class="font-sans">Failed to transform data. Original error:</p>
+        </div>
+        <p>
+          {previewError}
+        </p>
+      </div>
+    {/if}
   </MenuItem>
 </Menu>

--- a/src/lib/components/data/TransformationAlert.svelte
+++ b/src/lib/components/data/TransformationAlert.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import { slide } from 'svelte/transition';
+
+  import AlertIcon from '$lib/components/icons/AlertIcon.svelte';
+  import CheckIcon from '$lib/components/icons/CheckIcon.svelte';
+
+  type Alert =
+    | { kind: 'error'; message: string }
+    | { kind: 'success' }
+    | { kind: 'warning'; message: string };
+
+  export let alert: Alert;
+</script>
+
+<div class="stack stack-xs" transition:slide>
+  {#if alert.kind === 'error'}
+    <div
+      class="stack stack-xs rounded border border-red-400 bg-red-400 bg-opacity-50 px-2 py-1"
+    >
+      <div class="stack-h stack-h-xs items-center">
+        <AlertIcon />
+        <p class="font-sans">Failed to transform data. Original error:</p>
+      </div>
+      <p>
+        {alert.message}
+      </p>
+    </div>
+    <p class="font-sans">Try fixing the error and reexecuting the code.</p>
+  {:else if alert.kind === 'success'}
+    <div
+      class="stack-h stack-h-xs items-center rounded border border-green-400 bg-green-400 bg-opacity-50 px-2 py-1"
+    >
+      <CheckIcon />
+      <p>Successfully transformed data.</p>
+    </div>
+  {/if}
+</div>

--- a/src/lib/components/layers/FromAPI.svelte
+++ b/src/lib/components/layers/FromAPI.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { getContext } from 'svelte';
   import type { MapSourceDataEvent } from 'maplibre-gl';
-  import { featureCollection } from '@turf/helpers';
+  import { featureCollection as turfFeatureCollection } from '@turf/helpers';
   import kebabCase from 'lodash.kebabcase';
   import uniqueId from 'lodash.uniqueid';
 
@@ -53,8 +53,8 @@
       type: 'Fill',
       data: {
         url: endpoint,
-        geoJSON: featureCollection([]),
-        rawGeoJSON: featureCollection([])
+        geoJSON: turfFeatureCollection([]),
+        rawGeoJSON: turfFeatureCollection([])
       },
       style: {
         fill: {

--- a/src/lib/components/shared/MenuItem.svelte
+++ b/src/lib/components/shared/MenuItem.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
+  import cs from 'classnames';
+
   export let title: string;
+  export let titleClass = '';
 </script>
 
 <div class="stack stack-xs p-4 font-mono text-xs text-white">
   {#if $$slots.action}
-    <div class="flex items-center justify-between">
+    <div class={cs('flex items-center justify-between', titleClass)}>
       <p class="font-sans text-base font-medium tracking-wider">
         {title}
       </p>

--- a/yarn.lock
+++ b/yarn.lock
@@ -35,6 +35,14 @@
     "@lezer/common" "^1.0.0"
     "@lezer/javascript" "^1.0.0"
 
+"@codemirror/lang-json@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-json/-/lang-json-6.0.1.tgz#0a0be701a5619c4b0f8991f9b5e95fe33f462330"
+  integrity sha512-+T1flHdgpqDDlJZ2Lkil/rLiRy684WMLc74xUnjJH48GQdfJo/pudlTRreZmKwzP8/tGdKf83wlbAdOCzlJOGQ==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@lezer/json" "^1.0.0"
+
 "@codemirror/language@^6.0.0", "@codemirror/language@^6.6.0":
   version "6.6.0"
   resolved "https://registry.yarnpkg.com/@codemirror/language/-/language-6.6.0.tgz#2204407174a38a68053715c19e28ad61f491779f"
@@ -260,6 +268,14 @@
   dependencies:
     "@lezer/highlight" "^1.1.3"
     "@lezer/lr" "^1.3.0"
+
+"@lezer/json@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@lezer/json/-/json-1.0.1.tgz#3bf5641f3d1408ec31a5f9b29e4e96c6e3a232e6"
+  integrity sha512-nkVC27qiEZEjySbi6gQRuMwa2sDu2PtfjSgz0A4QF81QyRGm3kb2YRzLcOPcTEtmcwvrX/cej7mlhbwViA4WJw==
+  dependencies:
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
 
 "@lezer/lr@^1.0.0", "@lezer/lr@^1.3.0":
   version "1.3.3"


### PR DESCRIPTION
This PR adds support for a live preview to the data transformation interface. Here's what it looks like in action.

<img src="https://github.com/parkerziegler/cartokit/assets/19421190/e279e7dc-4b61-42bd-ae16-18a99250103b" alt="A demonstration of a user using the live preview in cartokit's data transformation interface." width="576" height="360" />

The live preview executes the user's code in a separate Web Worker on the currently selected feature, displaying the result immediately. When running the program results in a runtime error, we return the error message beneath the live preview. We don't yet handle warnings in this PR; they'll come later with support for GeoJSON validation.



