### PR TITLE
Begin work on #26. Add support for console logging to data transformation interface.

### DIFF
--- a/src/lib/components/data/AttributeEditor.svelte
+++ b/src/lib/components/data/AttributeEditor.svelte
@@ -140,6 +140,8 @@
             }
             break;
           case 'console':
+            previewError = '';
+
             message.args.forEach((entry) => {
               consoleOutput.push(JSON.stringify(entry, null, 2));
             });

--- a/src/lib/components/icons/TerminalIcon.svelte
+++ b/src/lib/components/icons/TerminalIcon.svelte
@@ -1,0 +1,11 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="16"
+  height="16"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"><polyline points="4 17 10 11 4 5" /></svg
+>

--- a/src/lib/utils/worker.ts
+++ b/src/lib/utils/worker.ts
@@ -67,8 +67,8 @@ export function transformationWorker(
     // Invoke user transformation code using an IIFE.
     // Wrap in a try-catch so we can send errors back to the main thread.
     [
-      `try {
-        (${interceptConsoleInWebWorker.toString()})();
+      `(${interceptConsoleInWebWorker.toString()})();
+      try {
         const data = (${program})(${JSON.stringify(featureCollection)});
         self.postMessage({ type: 'data', data });
       } catch (error) {
@@ -97,8 +97,8 @@ export function transformationWorker(
       error: new Error(
         `${event.message}. ${
           event.lineno -
-          1 -
-          interceptConsoleInWebWorker.toString().split('\n').length
+          interceptConsoleInWebWorker.toString().split('\n').length -
+          1
         }:${event.colno}.`
       )
     });


### PR DESCRIPTION
This PR adds simple `console.log` intercept to our data transformation interface, allowing users to debug their data transformation code. Here's what it looks like in action.

https://github.com/parkerziegler/cartokit/assets/19421190/259d1e40-c414-4ffe-ab1d-3d610cfcd37a

The implementation is fairly straightforward. We introduce a new function, `interceptConsoleInWebWorker`, that overwrites the Web Worker's native `console.log` to call `self.postMessage` with the evaluated arguments passed to `console.log`. We then store these evaluated arguments in local state and render them to the user. To match the behavior of the DevTools console, successive `console.log` calls "stack" in the UI and grow downward. `console.log` calls are evaluated live.

There is one small sticking point—we don't yet expand more complex data types like `Array`s and `Object`s. This will require a bit more engineering to do right, but it's being tracked in #26.