### PR TITLE
Resolve #53. Add support for code generation of multiple data transformations.

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -26,5 +26,8 @@ module.exports = {
         parser: '@typescript-eslint/parser'
       }
     }
-  ]
+  ],
+  rules: {
+    '@typescript-eslint/no-unused-vars': ['error', { varsIgnorePattern: '_' }]
+  }
 };

--- a/src/lib/codegen/codegen-fns.ts
+++ b/src/lib/codegen/codegen-fns.ts
@@ -8,13 +8,10 @@ import type { CartoKitIR } from '$lib/stores/ir';
  *
  * @returns – A program fragment.
  */
-export function codegenFns(
-  ir: CartoKitIR,
-  transformTable: Map<string, boolean>
-): string {
+export function codegenFns(ir: CartoKitIR): string {
   const fns: string[] = [];
 
-  if (isFetchGeoJSONRequired(ir, transformTable)) {
+  if (isFetchGeoJSONRequired(ir)) {
     fns.push(`async function fetchGeoJSON(url) {
       try {
         const response = await fetch(url);
@@ -40,12 +37,9 @@ export function codegenFns(
  * @returns – A Boolean value indicting whether we need to inline a function to
  * fetch GeoJSON hosted at a remote URL.
  */
-export function isFetchGeoJSONRequired(
-  { layers }: CartoKitIR,
-  transformTable: Map<string, boolean>
-): boolean {
+export function isFetchGeoJSONRequired({ layers }: CartoKitIR): boolean {
   for (const layer of Object.values(layers)) {
-    if (layer.data.url && transformTable.has(layer.id)) {
+    if (layer.data.url && layer.data.transformations.length > 0) {
       return true;
     }
   }

--- a/src/lib/codegen/codegen-imports.ts
+++ b/src/lib/codegen/codegen-imports.ts
@@ -14,7 +14,6 @@ import type { CartoKitIR } from '$lib/stores/ir';
  * @returns – A program fragment.
  */
 export function codegenImports(map: MapLibreMap, ir: CartoKitIR) {
-  console.log(JSON.stringify(Object.values(ir.layers)[0].style, null, 2));
   // Create a symbol table mapping layer ids to identifiers referencing imported
   // source data.
   const uploadTable = new Map<string, string>();

--- a/src/lib/codegen/codegen-imports.ts
+++ b/src/lib/codegen/codegen-imports.ts
@@ -4,8 +4,6 @@ import camelCase from 'lodash.camelcase';
 import { codegenFns } from '$lib/codegen/codegen-fns';
 import { codegenMap } from '$lib/codegen/codegen-map';
 import type { CartoKitIR } from '$lib/stores/ir';
-import type { CartoKitLayer } from '$lib/types/CartoKitLayer';
-import { getFeatureCollectionType } from '$lib/utils/geojson';
 
 /**
  * Generate a program fragment for all library and data source imports.
@@ -16,19 +14,12 @@ import { getFeatureCollectionType } from '$lib/utils/geojson';
  * @returns – A program fragment.
  */
 export function codegenImports(map: MapLibreMap, ir: CartoKitIR) {
+  console.log(JSON.stringify(Object.values(ir.layers)[0].style, null, 2));
   // Create a symbol table mapping layer ids to identifiers referencing imported
   // source data.
   const uploadTable = new Map<string, string>();
 
-  // Create a symbol table to track which layers performed cross-geometry data
-  // transformations.
-  const transformTable = new Map<string, boolean>();
-
   const fileImports = Object.values(ir.layers).reduce((acc, layer) => {
-    if (isTransformRequired(layer)) {
-      transformTable.set(layer.id, true);
-    }
-
     if (layer.data.fileName) {
       const dataIdent = camelCase(layer.displayName);
       uploadTable.set(layer.id, dataIdent);
@@ -40,30 +31,47 @@ export function codegenImports(map: MapLibreMap, ir: CartoKitIR) {
   }, '');
 
   const imports = `import mapboxgl from 'mapbox-gl';
-  ${transformTable.size > 0 ? "import * as turf from '@turf/turf';\n" : ''}
+  ${isTurfRequired(ir) ? "import * as turf from '@turf/turf';\n" : ''}
+  ${isLodashFlowRequired(ir) ? "import flow from 'lodash.flow';\n" : ''}
   ${fileImports}
   
   mapboxgl.accessToken = '<YOUR_MAPBOX_ACCESS_TOKEN>'`;
 
   return `${imports}
 
-  ${codegenFns(ir, transformTable)}
+  ${codegenFns(ir)}
   
-  ${codegenMap({ map, ir, uploadTable, transformTable })}`;
+  ${codegenMap(map, ir, uploadTable)}`;
 }
 
 /**
- * Determine whether some form of cross-geometry transformation was performed on
- * the original source data of a layer.
+ * Determine whether @turf/turf is required for cross-geometry transformations.
  *
- * @param layer – A CartoKit layer.
+ * @param ir – The CartoKit IR.
  *
- * @returns – A Boolean value indicating whether a cross-geometry transformation
- * was performed on the input layer.
+ * @returns – A Boolean value indicating whether @turf/turf is required.
  */
-function isTransformRequired(layer: CartoKitLayer): boolean {
-  const geometry = getFeatureCollectionType(layer.data.geoJSON);
-  const rawGeometry = getFeatureCollectionType(layer.data.rawGeoJSON);
+function isTurfRequired({ layers }: CartoKitIR): boolean {
+  for (const layer of Object.values(layers)) {
+    return (
+      layer.data.transformations.filter(
+        (transformation) => transformation.type === 'geometric'
+      ).length > 0
+    );
+  }
 
-  return geometry !== rawGeometry;
+  return false;
+}
+
+/**
+ * Determine whether lodash.flow is required for chaining transformations.
+ *
+ * @param ir – The CartoKit IR.
+ *
+ * @returns - A Boolean value indicating whether lodash.flow is required.
+ */
+function isLodashFlowRequired({ layers }: CartoKitIR): boolean {
+  return Object.values(layers).some(
+    (layer) => layer.data.transformations.length > 1
+  );
 }

--- a/src/lib/codegen/codegen-map.ts
+++ b/src/lib/codegen/codegen-map.ts
@@ -6,32 +6,21 @@ import { codegenLayer } from '$lib/codegen/codegen-layer';
 import { codegenSource } from '$lib/codegen/codegen-source';
 import type { CartoKitIR } from '$lib/stores/ir';
 
-interface CodegenMapParams {
-  map: MapLibreMap;
-  ir: CartoKitIR;
-  uploadTable: Map<string, string>;
-  transformTable: Map<string, boolean>;
-}
-
 /**
  * Generate a Mapbox GL JS program fragment for layer sources, layer renders,
  * and the top-level map instance.
  *
- * @params params – Required parameters to generate the Mapbox GL JS program
- * fragment.
  * @param map – The MapLibre GL JS map instance.
  * @param ir – The CartoKit IR.
  * @param uploadTable – The symbol table tracking file uploads.
- * @param transformTable – The transformation symbol table.
  *
  * @returns – A Mapbox GL JS program fragment.
  */
-export function codegenMap({
-  map,
-  ir,
-  uploadTable,
-  transformTable
-}: CodegenMapParams): string {
+export function codegenMap(
+  map: MapLibreMap,
+  ir: CartoKitIR,
+  uploadTable: Map<string, string>
+): string {
   const layerSources = Object.values(ir.layers).reduce((p, layer) => {
     return p.concat('\n\n' + codegenSource(layer, uploadTable));
   }, '');
@@ -41,7 +30,7 @@ export function codegenMap({
   }, '');
 
   const { lng, lat } = map.getCenter();
-  const isLoadAsync = isFetchGeoJSONRequired(ir, transformTable);
+  const isLoadAsync = isFetchGeoJSONRequired(ir);
 
   const program = `
   const map = new mapboxgl.Map({
@@ -54,7 +43,7 @@ export function codegenMap({
     zoom: ${map.getZoom()}
   });
 
-  map.on('load', ${isLoadAsync ? 'async' : ''}() => {
+  map.on('load', ${isLoadAsync ? 'async ' : ''}() => {
     ${layerSources}
 
     ${layerRenders}

--- a/src/lib/codegen/codegen-source.ts
+++ b/src/lib/codegen/codegen-source.ts
@@ -1,5 +1,5 @@
-import type { CartoKitLayer } from '$lib/types/CartoKitLayer';
 import { codegenTransformations } from '$lib/codegen/codegen-transformations';
+import type { CartoKitLayer } from '$lib/types/CartoKitLayer';
 
 /**
  * Generate the data source for a CartoKit layer.

--- a/src/lib/codegen/codegen-source.ts
+++ b/src/lib/codegen/codegen-source.ts
@@ -1,11 +1,5 @@
-import camelCase from 'lodash.camelcase';
-
-import type {
-  CartoKitLayer,
-  CartoKitDotDensityLayer,
-  CartoKitProportionalSymbolLayer
-} from '$lib/types/CartoKitLayer';
-import { getFeatureCollectionType } from '$lib/utils/geojson';
+import type { CartoKitLayer } from '$lib/types/CartoKitLayer';
+import { codegenTransformations } from '$lib/codegen/codegen-transformations';
 
 /**
  * Generate the data source for a CartoKit layer.
@@ -19,126 +13,14 @@ export function codegenSource(
   layer: CartoKitLayer,
   uploadTable: Map<string, string>
 ): string {
-  const geometry = getFeatureCollectionType(layer.data.geoJSON);
-  const rawGeometry = getFeatureCollectionType(layer.data.rawGeoJSON);
+  const { transformation, data } = codegenTransformations(layer, uploadTable);
 
-  let transformation = '';
-  let features = '';
+  return `
+  ${transformation}
 
-  if (
-    (geometry === 'Point' || geometry === 'MultiPoint') &&
-    (rawGeometry === 'Polygon' || rawGeometry === 'MultiPolygon')
-  ) {
-    switch (layer.type) {
-      case 'Proportional Symbol':
-        ({ transformation, features } = codegenProportionalSymbolTransformation(
-          layer,
-          uploadTable
-        ));
-        break;
-      case 'Dot Density':
-        ({ transformation, features } = codegenDotDensityTransformation(
-          layer,
-          uploadTable
-        ));
-        break;
-      default:
-        break;
-    }
-  }
-
-  return transformation.concat(`
   map.addSource('${layer.id}', {
 		type: 'geojson',
-		data: ${
-      transformation
-        ? features
-        : layer.data.url
-        ? `"${layer.data.url}"`
-        : `${camelCase(layer.displayName)}`
-    }
+		data: ${data}
 	});
-  `);
-}
-
-interface TransformationProgramFragment {
-  transformation: string;
-  features: string;
-}
-
-/**
- * Generate the data transformation for a CartoKitProportionalSymbolLayer.
- *
- * @param layer – A CartoKitProportionalSymbolLayer.
- * @param uploadTable – The symbol table tracking file uploads.
- *
- * @returns – A "transformation" and "features" program fragment.
- */
-function codegenProportionalSymbolTransformation(
-  layer: CartoKitProportionalSymbolLayer,
-  uploadTable: Map<string, string>
-): TransformationProgramFragment {
-  const dataIdent = uploadTable.get(layer.id) ?? camelCase(layer.displayName);
-  const fetchData =
-    layer.data.url && !uploadTable.has(layer.id)
-      ? `const ${dataIdent} = await fetchGeoJSON('${layer.data.url}');\n`
-      : '';
-
-  const transformation = `
-    ${fetchData}
-		const centroids = ${dataIdent}.features.map((feature) => {
-			return turf.feature(turf.centroid(feature).geometry, feature.properties);
-		});
-	`;
-
-  const features = 'turf.featureCollection(centroids)';
-
-  return { transformation, features };
-}
-
-/**
- * Generate the data transformation for a CartoKitProportionalSymbolLayer.
- *
- * @param layer – A CartoKitDotDensityLayer.
- * @param uploadTable – The symbol table tracking file uploads.
- *
- * @returns – A "transformation" and "features" program fragment.
- */
-function codegenDotDensityTransformation(
-  layer: CartoKitDotDensityLayer,
-  uploadTable: Map<string, string>
-): TransformationProgramFragment {
-  const dataIdent = uploadTable.get(layer.id) ?? camelCase(layer.displayName);
-  const fetchData =
-    layer.data.url && !uploadTable.has(layer.id)
-      ? `const ${dataIdent} = await fetchGeoJSON('${layer.data.url}');\n`
-      : '';
-
-  const transformation = `
-  ${fetchData}
-	const dots = ${dataIdent}.features.flatMap((feature) => {
-		const numPoints = Math.floor(
-      feature.properties['${layer.style.dots.attribute}'] / ${layer.style.dots.value}
-    );
-
-		const bbox = turf.bbox(feature);
-		const selectedFeatures = [];
-
-		while (selectedFeatures.length < numPoints) {
-			const candidate = turf.randomPoint(1, { bbox }).features[0];
-
-			if (turf.booleanWithin(candidate, feature)) {
-				selectedFeatures.push(candidate);
-			}
-		}
-
-		return selectedFeatures.flatMap((point) => {
-			return turf.feature(point.geometry, feature.properties);
-		});
-	});
-	`;
-
-  const features = 'turf.featureCollection(dots)';
-
-  return { transformation, features };
+  `;
 }

--- a/src/lib/codegen/codegen-transformations.ts
+++ b/src/lib/codegen/codegen-transformations.ts
@@ -1,0 +1,43 @@
+import camelCase from 'lodash.camelcase';
+import type { CartoKitLayer } from '$lib/types/CartoKitLayer';
+
+interface TransformationProgramFragment {
+  transformation: string;
+  data: string;
+}
+
+export function codegenTransformations(
+  layer: CartoKitLayer,
+  uploadTable: Map<string, string>
+): TransformationProgramFragment {
+  const transformations = layer.data.transformations;
+  const dataIdent = uploadTable.get(layer.id) ?? camelCase(layer.displayName);
+  const fetchData =
+    layer.data.url && !uploadTable.has(layer.id)
+      ? `const ${dataIdent} = await fetchGeoJSON('${layer.data.url}');\n`
+      : '';
+
+  switch (transformations.length) {
+    case 0:
+      return {
+        transformation: '',
+        data: layer.data.url ? `"${layer.data.url}"` : dataIdent
+      };
+    case 1:
+      return {
+        transformation: `${fetchData}
+        ${transformations[0].definition}`,
+        data: `${transformations[0].name}(${dataIdent})`
+      };
+    default:
+      return {
+        transformation: `${fetchData}
+        ${transformations
+          .map((transformation) => transformation.definition)
+          .join('\n\n')}`,
+        data: `flow(${transformations
+          .map((transformation) => transformation.name)
+          .join(', ')})(${dataIdent})`
+      };
+  }
+}

--- a/src/lib/components/data/AttributeEditor.svelte
+++ b/src/lib/components/data/AttributeEditor.svelte
@@ -19,6 +19,7 @@
     CartoKitDotDensityLayer,
     CartoKitProportionalSymbolLayer
   } from '$lib/types/CartoKitLayer';
+  import { functionNameRe } from '$lib/utils/regex';
   import { transformationWorker } from '$lib/utils/worker';
 
   export let onClose: () => void;
@@ -58,7 +59,7 @@
   }
   onMount(() => {
     view = new EditorView({
-      doc: `function transform(geoJSON) {
+      doc: `function transformGeoJSON(geoJSON) {
   return geoJSON;
 }`,
       extensions: [
@@ -86,7 +87,7 @@
     transformationWorker(program, layer.data.geoJSON, (message) => {
       switch (message.type) {
         case 'data': {
-          const name = /^function\s+([\w$]+)\s*\(/.exec(program);
+          const name = functionNameRe.exec(program);
 
           dispatchLayerUpdate({
             type: 'transformation',

--- a/src/lib/components/layers/FromAPI.svelte
+++ b/src/lib/components/layers/FromAPI.svelte
@@ -54,7 +54,8 @@
       data: {
         url: endpoint,
         geoJSON: turfFeatureCollection([]),
-        rawGeoJSON: turfFeatureCollection([])
+        rawGeoJSON: turfFeatureCollection([]),
+        transformations: []
       },
       style: {
         fill: {

--- a/src/lib/components/layers/FromFile.svelte
+++ b/src/lib/components/layers/FromFile.svelte
@@ -54,7 +54,8 @@
           data: {
             geoJSON: normalizeGeoJSONToFeatureCollection(geojson),
             rawGeoJSON: normalizeGeoJSONToFeatureCollection(geojson),
-            fileName: file.name
+            fileName: file.name,
+            transformations: []
           },
           style: {
             fill: {

--- a/src/lib/types/CartoKitLayer.ts
+++ b/src/lib/types/CartoKitLayer.ts
@@ -2,6 +2,7 @@ import type { FeatureCollection } from 'geojson';
 
 import type { MapType } from '$lib/types/map-types';
 import type { ColorScale, ColorScheme } from '$lib/types/color';
+import type { Transformation } from '$lib/types/transformation';
 
 interface Layer {
   id: string;
@@ -12,6 +13,7 @@ interface Layer {
     geoJSON: FeatureCollection;
     rawGeoJSON: FeatureCollection;
     fileName?: string;
+    transformations: Transformation[];
   };
 }
 

--- a/src/lib/types/transformation.ts
+++ b/src/lib/types/transformation.ts
@@ -1,0 +1,5 @@
+export interface Transformation {
+  name: string;
+  definition: string;
+  type: 'geometric' | 'statistical';
+}

--- a/src/lib/utils/regex.ts
+++ b/src/lib/utils/regex.ts
@@ -1,0 +1,1 @@
+export const functionNameRe = /^function\s+([\w$]+)\s*\(/;

--- a/src/lib/utils/transformation.ts
+++ b/src/lib/utils/transformation.ts
@@ -1,0 +1,51 @@
+import type { Transformation } from '$lib/types/transformation';
+
+export function transformProportionalSymbol(): Transformation {
+  return {
+    name: 'transformProportionalSymbol',
+    definition: `
+    function transformProportionalSymbol(geoJSON) {
+      const centroids = geoJSON.features.map((feature) => {
+        return turf.feature(turf.centroid(feature).geometry, feature.properties);
+      });
+
+      return turf.featureCollection(centroids)
+    }`,
+    type: 'geometric'
+  };
+}
+
+export function transformDotDensity(
+  attribute: string,
+  dotValue: number
+): Transformation {
+  return {
+    name: 'transformDotDensity',
+    definition: `
+    function transformDotDensity(geoJSON) {
+      const dots = geoJSON.features.flatMap((feature) => {
+        const numPoints = Math.floor(
+          feature.properties['${attribute}'] / ${dotValue}
+        );
+
+        const bbox = turf.bbox(feature);
+        const selectedFeatures = [];
+
+        while (selectedFeatures.length < numPoints) {
+          const candidate = turf.randomPoint(1, { bbox }).features[0];
+
+          if (turf.booleanWithin(candidate, feature)) {
+            selectedFeatures.push(candidate);
+          }
+        }
+
+        return selectedFeatures.flatMap((point) => {
+          return turf.feature(point.geometry, feature.properties);
+        });
+      });
+
+      return turf.featureCollection(dots);
+    }`,
+    type: 'geometric'
+  };
+}

--- a/src/lib/utils/worker.ts
+++ b/src/lib/utils/worker.ts
@@ -1,4 +1,4 @@
-import type { GeoJSON, FeatureCollection, Feature } from 'geojson';
+import type { GeoJSON, FeatureCollection } from 'geojson';
 
 import { normalizeGeoJSONToFeatureCollection } from './geojson';
 
@@ -46,7 +46,7 @@ export function sourceWorker(
 }
 
 type TransformationWorkerMessage =
-  | { type: 'data'; data: Feature[] }
+  | { type: 'data'; data: FeatureCollection }
   | { type: 'console'; args: unknown[] }
   | { type: 'error'; error: Error };
 
@@ -60,7 +60,7 @@ type TransformationWorkerMessage =
  */
 export function transformationWorker(
   program: string,
-  featureCollection: Feature[],
+  featureCollection: FeatureCollection,
   cb: (message: TransformationWorkerMessage) => void
 ) {
   const blob = new Blob(


### PR DESCRIPTION
This PR adds support for code generation of multiple data transformations operating on a single layer. Previously, code generation of map type transitions was treated as distinct from user-defined transformations. However, we want to start treating them uniformly as the data transformation interface becomes more fully featured (e.g., supports reordering of transformations).

This PR lays the foundation for this work by introducing a new `transformations` key into the definition of `CartoKitLayer.data`. A given `transformation` consists of:

- `name` — The name of the transformation function. We use this to determine if a function name is unique in its enclosing scope in the generated program.
- `definition` — The transformation function body.
- `type` — A union type indicating whether the transformation operates on the geometry of the data or if purely on the attributes.

For example, in the screenshot below, I've sequenced a transition from a Fill layer to a Proportional Symbol layer followed by a custom transformation function adding a new attribute. Notice how the generated program has changed to bring these functions into the appropriate scope and inject function call sites into the program where we need to obtain the final data.

<img width="1811" alt="An example interaction in cartokit where a user has (1) transformed a Fill layer to a Proportional Symbol layer, and (2) defined a custom transformation function. The program on the right reflects both transformation functions." src="https://github.com/parkerziegler/cartokit/assets/19421190/ed718111-aad3-422b-a0fa-616061026249">
