### PR TITLE
feat: Support LineString and MultiLineString geometries.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -26,3 +26,6 @@ yarn.lock
 
 # Svelte
 svelte.config.js
+
+# ESLint
+.eslintrc.cjs

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -31,6 +31,7 @@ module.exports = {
     }
   ],
   rules: {
-    '@typescript-eslint/no-unused-vars': ['error', { varsIgnorePattern: '_' }]
+    '@typescript-eslint/no-unused-vars': ['error', { varsIgnorePattern: '_' }],
+    '@typescript-eslint/switch-exhaustiveness-check': 'error'
   }
 };

--- a/src/lib/codegen/codegen-layer.ts
+++ b/src/lib/codegen/codegen-layer.ts
@@ -8,8 +8,39 @@ import type { CartoKitLayer } from '$lib/types/CartoKitLayer';
  *
  * @returns – A Mapbox GL JS program fragment.
  */
-export function codegenLayer(layer: CartoKitLayer): string {
+export const codegenLayer = (layer: CartoKitLayer): string => {
   switch (layer.type) {
+    case 'Point':
+    case 'Proportional Symbol':
+    case 'Dot Density': {
+      const fill = codegenFill(layer);
+      const stroke = codegenStroke(layer);
+
+      return `
+        map.addLayer({
+          id: '${layer.id}',
+          source: '${layer.id}',
+          type: 'circle',
+          ${
+            fill || stroke
+              ? `paint: { ${[fill, stroke].filter(Boolean).join(',\n')} }`
+              : ''
+          }
+        });
+      `;
+    }
+    case 'Line': {
+      const stroke = codegenStroke(layer);
+
+      return `
+        map.addLayer({
+          id: '${layer.id}',
+          source: '${layer.id}',
+          type: 'line',
+          ${stroke ? `paint: { ${stroke} }` : ''}
+        });
+      `;
+    }
     case 'Fill': {
       let fillLayer = '';
       let strokeLayer = '';
@@ -59,24 +90,5 @@ export function codegenLayer(layer: CartoKitLayer): string {
 
       return [fillLayer, strokeLayer].filter(Boolean).join('\n\n');
     }
-    case 'Point':
-    case 'Proportional Symbol':
-    case 'Dot Density': {
-      const fill = codegenFill(layer);
-      const stroke = codegenStroke(layer);
-
-      return `
-        map.addLayer({
-          id: '${layer.id}',
-          source: '${layer.id}',
-          type: 'circle',
-          ${
-            fill || stroke
-              ? `paint: { ${[fill, stroke].filter(Boolean).join(',\n')} }`
-              : ''
-          }
-        });
-      `;
-    }
   }
-}
+};

--- a/src/lib/codegen/codegen-paint.ts
+++ b/src/lib/codegen/codegen-paint.ts
@@ -156,25 +156,6 @@ export const codegenStroke = (layer: CartoKitLayer): string => {
         .join(',\n');
     }
     case 'Line':
-      return [
-        withDefault(
-          'line-color',
-          layer.style.stroke.color,
-          MAPBOX_DEFAULTS['line-color']
-        ),
-        withDefault(
-          'line-width',
-          layer.style.stroke.width,
-          MAPBOX_DEFAULTS['line-width']
-        ),
-        withDefault(
-          'line-opacity',
-          layer.style.stroke.opacity,
-          MAPBOX_DEFAULTS['line-opacity']
-        )
-      ]
-        .filter(Boolean)
-        .join(',\n');
     case 'Fill':
     case 'Choropleth': {
       if (!layer.style.stroke) {

--- a/src/lib/codegen/codegen-paint.ts
+++ b/src/lib/codegen/codegen-paint.ts
@@ -10,7 +10,7 @@ import { MAPBOX_DEFAULTS } from '$lib/utils/constants';
  *
  * @returns – A Mapbox GL JS program fragment representing the layer's fill.
  */
-export function codegenFill(layer: CartoKitLayer): string {
+export const codegenFill = (layer: CartoKitLayer): string => {
   switch (layer.type) {
     case 'Point': {
       if (!layer.style.fill) {
@@ -32,38 +32,6 @@ export function codegenFill(layer: CartoKitLayer): string {
           'circle-opacity',
           layer.style.fill.opacity,
           MAPBOX_DEFAULTS['circle-opacity']
-        )
-      ]
-        .filter(Boolean)
-        .join(',\n');
-    }
-    case 'Fill': {
-      if (!layer.style.fill) {
-        return '';
-      }
-
-      return [
-        withDefault(
-          'fill-color',
-          layer.style.fill.color,
-          MAPBOX_DEFAULTS['fill-color']
-        ),
-        withDefault(
-          'fill-opacity',
-          layer.style.fill.opacity,
-          MAPBOX_DEFAULTS['fill-opacity']
-        )
-      ]
-        .filter(Boolean)
-        .join(',\n');
-    }
-    case 'Choropleth': {
-      return [
-        `'fill-color': ${JSON.stringify(deriveColorScale(layer))}`,
-        withDefault(
-          'fill-opacity',
-          layer.style.fill.opacity,
-          MAPBOX_DEFAULTS['fill-opacity']
         )
       ]
         .filter(Boolean)
@@ -115,8 +83,42 @@ export function codegenFill(layer: CartoKitLayer): string {
         .filter(Boolean)
         .join(',\n');
     }
+    case 'Line':
+      return '';
+    case 'Fill': {
+      if (!layer.style.fill) {
+        return '';
+      }
+
+      return [
+        withDefault(
+          'fill-color',
+          layer.style.fill.color,
+          MAPBOX_DEFAULTS['fill-color']
+        ),
+        withDefault(
+          'fill-opacity',
+          layer.style.fill.opacity,
+          MAPBOX_DEFAULTS['fill-opacity']
+        )
+      ]
+        .filter(Boolean)
+        .join(',\n');
+    }
+    case 'Choropleth': {
+      return [
+        `'fill-color': ${JSON.stringify(deriveColorScale(layer))}`,
+        withDefault(
+          'fill-opacity',
+          layer.style.fill.opacity,
+          MAPBOX_DEFAULTS['fill-opacity']
+        )
+      ]
+        .filter(Boolean)
+        .join(',\n');
+    }
   }
-}
+};
 
 /**
  * Generate a Mapbox GL JS program fragment representing the layer's stroke.
@@ -124,34 +126,8 @@ export function codegenFill(layer: CartoKitLayer): string {
  * @param layer – A CartoKit layer.
  * @returns – A Mapbox GL JS program fragment representing the layer's stroke.
  */
-export function codegenStroke(layer: CartoKitLayer): string {
+export const codegenStroke = (layer: CartoKitLayer): string => {
   switch (layer.type) {
-    case 'Fill':
-    case 'Choropleth': {
-      if (!layer.style.stroke) {
-        return '';
-      }
-
-      return [
-        withDefault(
-          'line-color',
-          layer.style.stroke.color,
-          MAPBOX_DEFAULTS['line-color']
-        ),
-        withDefault(
-          'line-width',
-          layer.style.stroke.width,
-          MAPBOX_DEFAULTS['line-width']
-        ),
-        withDefault(
-          'line-opacity',
-          layer.style.stroke.opacity,
-          MAPBOX_DEFAULTS['line-opacity']
-        )
-      ]
-        .filter(Boolean)
-        .join(',\n');
-    }
     case 'Point':
     case 'Proportional Symbol':
     case 'Dot Density': {
@@ -179,8 +155,54 @@ export function codegenStroke(layer: CartoKitLayer): string {
         .filter(Boolean)
         .join(',\n');
     }
+    case 'Line':
+      return [
+        withDefault(
+          'line-color',
+          layer.style.stroke.color,
+          MAPBOX_DEFAULTS['line-color']
+        ),
+        withDefault(
+          'line-width',
+          layer.style.stroke.width,
+          MAPBOX_DEFAULTS['line-width']
+        ),
+        withDefault(
+          'line-opacity',
+          layer.style.stroke.opacity,
+          MAPBOX_DEFAULTS['line-opacity']
+        )
+      ]
+        .filter(Boolean)
+        .join(',\n');
+    case 'Fill':
+    case 'Choropleth': {
+      if (!layer.style.stroke) {
+        return '';
+      }
+
+      return [
+        withDefault(
+          'line-color',
+          layer.style.stroke.color,
+          MAPBOX_DEFAULTS['line-color']
+        ),
+        withDefault(
+          'line-width',
+          layer.style.stroke.width,
+          MAPBOX_DEFAULTS['line-width']
+        ),
+        withDefault(
+          'line-opacity',
+          layer.style.stroke.opacity,
+          MAPBOX_DEFAULTS['line-opacity']
+        )
+      ]
+        .filter(Boolean)
+        .join(',\n');
+    }
   }
-}
+};
 
 /**
  * Return a Mapbox GL JS program fragment representing a property-value pair,
@@ -192,14 +214,14 @@ export function codegenStroke(layer: CartoKitLayer): string {
  *
  * @returns – A (potentially empty) Mapbox GL JS program fragment.
  */
-function withDefault<T extends string | number>(
+const withDefault = <T extends string | number>(
   mapboxProperty: string,
   cartokitValue: T,
   defaultValue: T
-): string {
+): string => {
   return cartokitValue !== defaultValue
     ? `'${mapboxProperty}': ${
         typeof cartokitValue === 'string' ? `'${cartokitValue}'` : cartokitValue
       }`
     : '';
-}
+};

--- a/src/lib/components/color/StrokeModifier.svelte
+++ b/src/lib/components/color/StrokeModifier.svelte
@@ -2,25 +2,36 @@
   import MinusIcon from '$lib/components/icons/MinusIcon.svelte';
   import PlusIcon from '$lib/components/icons/PlusIcon.svelte';
   import { dispatchLayerUpdate } from '$lib/interaction/update';
-  import type { CartoKitLayer } from '$lib/types/CartoKitLayer';
+  import type {
+    CartoKitPointLayer,
+    CartoKitProportionalSymbolLayer,
+    CartoKitDotDensityLayer,
+    CartoKitFillLayer,
+    CartoKitChoroplethLayer
+  } from '$lib/types/CartoKitLayer';
 
-  export let layer: CartoKitLayer;
+  export let layer:
+    | CartoKitPointLayer
+    | CartoKitProportionalSymbolLayer
+    | CartoKitDotDensityLayer
+    | CartoKitFillLayer
+    | CartoKitChoroplethLayer;
 
-  function onRemoveStroke() {
+  const onRemoveStroke = (): void => {
     dispatchLayerUpdate({
       type: 'remove-stroke',
       layer,
       payload: {}
     });
-  }
+  };
 
-  function onAddStroke() {
+  const onAddStroke = (): void => {
     dispatchLayerUpdate({
       type: 'add-stroke',
       layer,
       payload: {}
     });
-  }
+  };
 </script>
 
 {#if layer.style.stroke}

--- a/src/lib/components/icons/LineIcon.svelte
+++ b/src/lib/components/icons/LineIcon.svelte
@@ -1,0 +1,13 @@
+<svg
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    d="M2 2C2 6.5 2.8 16 6 18C9.2 20 11.3333 14.8333 12 12M22.05 21.75C22.05 17.25 21.25 7.75 18.05 5.75C14.85 3.75 12.7167 8.91667 12.05 11.75"
+    stroke="currentColor"
+    stroke-linecap="round"
+  />
+</svg>

--- a/src/lib/components/layers/LayerEntry.svelte
+++ b/src/lib/components/layers/LayerEntry.svelte
@@ -45,16 +45,16 @@
       <span class="shrink-0">
         {#if layer.type === 'Point'}
           <PointIcon />
+        {:else if layer.type === 'Proportional Symbol'}
+          <ProportionalSymbolIcon />
+        {:else if layer.type === 'Dot Density'}
+          <DotDensityIcon />
         {:else if layer.type === 'Line'}
           <LineIcon />
         {:else if layer.type === 'Fill'}
           <FillIcon />
         {:else if layer.type === 'Choropleth'}
           <ChoroplethIcon />
-        {:else if layer.type === 'Proportional Symbol'}
-          <ProportionalSymbolIcon />
-        {:else if layer.type === 'Dot Density'}
-          <DotDensityIcon />
         {/if}
       </span>
       <span class="ml-2 mr-8 truncate text-sm">{layer.displayName}</span>
@@ -71,15 +71,15 @@
   </div>
   {#if layer.type === 'Point'}
     <PointLegend {layer} />
+  {:else if layer.type === 'Proportional Symbol'}
+    <ProportionalSymbolLegend {layer} />
+  {:else if layer.type === 'Dot Density'}
+    <DotDensityLegend {layer} />
   {:else if layer.type === 'Line'}
     <LineLegend {layer} />
   {:else if layer.type === 'Fill'}
     <FillLegend {layer} />
   {:else if layer.type === 'Choropleth'}
     <ChoroplethLegend {layer} />
-  {:else if layer.type === 'Proportional Symbol'}
-    <ProportionalSymbolLegend {layer} />
-  {:else if layer.type === 'Dot Density'}
-    <DotDensityLegend {layer} />
   {/if}
 </li>

--- a/src/lib/components/layers/LayerEntry.svelte
+++ b/src/lib/components/layers/LayerEntry.svelte
@@ -5,6 +5,8 @@
   import DotDensityLegend from '$lib/components/legends/DotDensityLegend.svelte';
   import FillIcon from '$lib/components/icons/FillIcon.svelte';
   import FillLegend from '$lib/components/legends/FillLegend.svelte';
+  import LineIcon from '$lib/components/icons/LineIcon.svelte';
+  import LineLegend from '$lib/components/legends/LineLegend.svelte';
   import PointIcon from '$lib/components/icons/PointIcon.svelte';
   import PointLegend from '$lib/components/legends/PointLegend.svelte';
   import ProportionalSymbolIcon from '$lib/components/icons/ProportionalSymbolIcon.svelte';
@@ -43,6 +45,8 @@
       <span class="shrink-0">
         {#if layer.type === 'Point'}
           <PointIcon />
+        {:else if layer.type === 'Line'}
+          <LineIcon />
         {:else if layer.type === 'Fill'}
           <FillIcon />
         {:else if layer.type === 'Choropleth'}
@@ -67,6 +71,8 @@
   </div>
   {#if layer.type === 'Point'}
     <PointLegend {layer} />
+  {:else if layer.type === 'Line'}
+    <LineLegend {layer} />
   {:else if layer.type === 'Fill'}
     <FillLegend {layer} />
   {:else if layer.type === 'Choropleth'}

--- a/src/lib/components/legends/LineLegend.svelte
+++ b/src/lib/components/legends/LineLegend.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import type { CartoKitLineLayer } from '$lib/types/CartoKitLayer';
+  import { getLayerGeometryType } from '$lib/utils/geojson';
+
+  export let layer: CartoKitLineLayer;
+  $: geometryType = getLayerGeometryType(layer.data.geoJSON);
+</script>
+
+<div class="stack-h stack-h-xs ml-8 items-center">
+  <svg viewBox="0 0 16 16" width="16" height="16">
+    <line
+      x1="0"
+      y1="8"
+      x2="16"
+      y2="8"
+      stroke={layer.style.stroke.color}
+      stroke-width={layer.style.stroke.width}
+      stroke-opacity={layer.style.stroke.opacity}
+    />
+  </svg>
+  <span
+    >{layer.data.geoJSON.features.length}
+    {geometryType + (geometryType.length !== 1 ? 's' : '')}</span
+  >
+</div>

--- a/src/lib/components/legends/LineLegend.svelte
+++ b/src/lib/components/legends/LineLegend.svelte
@@ -7,12 +7,16 @@
 </script>
 
 <div class="stack-h stack-h-xs ml-8 items-center">
-  <svg viewBox="0 0 16 16" width="16" height="16">
+  <svg
+    viewBox="0 0 16 {layer.style.stroke.width}"
+    width="16"
+    height={layer.style.stroke.width}
+  >
     <line
       x1="0"
-      y1="8"
+      y1={layer.style.stroke.width / 2}
       x2="16"
-      y2="8"
+      y2={layer.style.stroke.width / 2}
       stroke={layer.style.stroke.color}
       stroke-width={layer.style.stroke.width}
       stroke-opacity={layer.style.stroke.opacity}

--- a/src/lib/components/map-types/MapTypeSelect.svelte
+++ b/src/lib/components/map-types/MapTypeSelect.svelte
@@ -12,13 +12,13 @@
     label: mapType
   }));
 
-  function onChange(event: CustomEvent<{ value: MapType }>) {
+  const onChange = (event: CustomEvent<{ value: MapType }>) => {
     dispatchLayerUpdate({
       type: 'map-type',
       layer,
       payload: { mapType: event.detail.value }
     });
-  }
+  };
 </script>
 
 <Select {options} selected={layer.type} on:change={onChange} />

--- a/src/lib/components/properties/LinePropertiesPanel.svelte
+++ b/src/lib/components/properties/LinePropertiesPanel.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import MenuItem from '$lib/components/shared/MenuItem.svelte';
+  import StrokePicker from '$lib/components/color/StrokePicker.svelte';
+  import type { CartoKitLineLayer } from '$lib/types/CartoKitLayer';
+
+  export let layer: CartoKitLineLayer;
+</script>
+
+<MenuItem title="Stroke">
+  <StrokePicker {layer} />
+</MenuItem>

--- a/src/lib/interaction/hover.ts
+++ b/src/lib/interaction/hover.ts
@@ -8,7 +8,7 @@ import { listeners } from '$lib/stores/listeners';
  * @param map – The top-level MapLibre GL map instance.
  * @param layer – The id of the layer to instrument.
  */
-export function instrumentPointHover(map: Map, layerId: string): void {
+export const instrumentPointHover = (map: Map, layerId: string): void => {
   const currentStrokeWidth = map.getPaintProperty(
     layerId,
     'circle-stroke-width'
@@ -32,9 +32,15 @@ export function instrumentPointHover(map: Map, layerId: string): void {
   ]);
 
   addHoverListeners(map, layerId);
-}
+};
 
-export function instrumentLineHover(map: Map, layerId: string): void {
+/**
+ * Add a hover effect to all features in a line layer.
+ *
+ * @param map – The top-level MapLibre GL map instance.
+ * @param layerId – The id of the layer to instrument.
+ */
+export const instrumentLineHover = (map: Map, layerId: string): void => {
   const currentStrokeWidth = map.getPaintProperty(layerId, 'line-width');
   const currentStrokeColor = map.getPaintProperty(layerId, 'line-color');
 
@@ -52,7 +58,7 @@ export function instrumentLineHover(map: Map, layerId: string): void {
   ]);
 
   addHoverListeners(map, layerId);
-}
+};
 
 /**
  * Add a hover effect to all features in a polygon layer.
@@ -60,7 +66,7 @@ export function instrumentLineHover(map: Map, layerId: string): void {
  * @param map – The top-level MapLibre GL map instance.
  * @param layerId – The id of the layer to instrument.
  */
-export function instrumentPolygonHover(map: Map, layerId: string): void {
+export const instrumentPolygonHover = (map: Map, layerId: string): void => {
   map.addLayer({
     id: `${layerId}-hover`,
     type: 'line',
@@ -77,7 +83,7 @@ export function instrumentPolygonHover(map: Map, layerId: string): void {
   });
 
   addHoverListeners(map, layerId);
-}
+};
 
 /**
  * Wire up event listeners for hover effects.
@@ -85,10 +91,10 @@ export function instrumentPolygonHover(map: Map, layerId: string): void {
  * @param map – The top-level MapLibre GL map instance.
  * @param layerId – The id of the layer to instrument.
  */
-function addHoverListeners(map: Map, layerId: string): void {
+const addHoverListeners = (map: Map, layerId: string): void => {
   let hoveredFeatureId: string | null = null;
 
-  function onMouseMove(event: MapLayerMouseEvent) {
+  const onMouseMove = (event: MapLayerMouseEvent): void => {
     if (event.features && event.features.length > 0) {
       if (hoveredFeatureId !== null) {
         map.setFeatureState(
@@ -106,9 +112,9 @@ function addHoverListeners(map: Map, layerId: string): void {
         );
       }
     }
-  }
+  };
 
-  function onMouseLeave() {
+  const onMouseLeave = (): void => {
     if (hoveredFeatureId !== null) {
       map.setFeatureState(
         { source: layerId, id: hoveredFeatureId },
@@ -116,7 +122,7 @@ function addHoverListeners(map: Map, layerId: string): void {
       );
     }
     hoveredFeatureId = null;
-  }
+  };
 
   map.on('mousemove', layerId, onMouseMove);
   map.on('mouseleave', layerId, onMouseLeave);
@@ -136,4 +142,4 @@ function addHoverListeners(map: Map, layerId: string): void {
       mouseleave: onMouseLeave
     });
   });
-}
+};

--- a/src/lib/interaction/hover.ts
+++ b/src/lib/interaction/hover.ts
@@ -3,31 +3,6 @@ import type { Map, MapLayerMouseEvent } from 'maplibre-gl';
 import { listeners } from '$lib/stores/listeners';
 
 /**
- * Add a hover effect to all features in a polygon layer.
- *
- * @param map – The top-level MapLibre GL map instance.
- * @param layerId – The id of the layer to instrument.
- */
-export function instrumentPolygonHover(map: Map, layerId: string): void {
-  map.addLayer({
-    id: `${layerId}-hover`,
-    type: 'line',
-    source: layerId,
-    paint: {
-      'line-color': '#FFFFFF',
-      'line-width': [
-        'case',
-        ['boolean', ['feature-state', 'hover'], false],
-        1,
-        0
-      ]
-    }
-  });
-
-  addHoverListeners(map, layerId);
-}
-
-/**
  * Add a hover effect to all features in a point layer.
  *
  * @param map – The top-level MapLibre GL map instance.
@@ -55,6 +30,51 @@ export function instrumentPointHover(map: Map, layerId: string): void {
     '#FFFFFF',
     currentStrokeColor ?? 'transparent'
   ]);
+
+  addHoverListeners(map, layerId);
+}
+
+export function instrumentLineHover(map: Map, layerId: string): void {
+  const currentStrokeWidth = map.getPaintProperty(layerId, 'line-width');
+  const currentStrokeColor = map.getPaintProperty(layerId, 'line-color');
+
+  map.setPaintProperty(layerId, 'line-width', [
+    'case',
+    ['boolean', ['feature-state', 'hover'], false],
+    1,
+    currentStrokeWidth ?? 0
+  ]);
+  map.setPaintProperty(layerId, 'line-color', [
+    'case',
+    ['boolean', ['feature-state', 'hover'], false],
+    '#FFFFFF',
+    currentStrokeColor ?? 'transparent'
+  ]);
+
+  addHoverListeners(map, layerId);
+}
+
+/**
+ * Add a hover effect to all features in a polygon layer.
+ *
+ * @param map – The top-level MapLibre GL map instance.
+ * @param layerId – The id of the layer to instrument.
+ */
+export function instrumentPolygonHover(map: Map, layerId: string): void {
+  map.addLayer({
+    id: `${layerId}-hover`,
+    type: 'line',
+    source: layerId,
+    paint: {
+      'line-color': '#FFFFFF',
+      'line-width': [
+        'case',
+        ['boolean', ['feature-state', 'hover'], false],
+        1,
+        0
+      ]
+    }
+  });
 
   addHoverListeners(map, layerId);
 }

--- a/src/lib/interaction/layer.ts
+++ b/src/lib/interaction/layer.ts
@@ -6,9 +6,9 @@ import kebabCase from 'lodash.kebabcase';
 import { deriveColorScale } from '$lib/interaction/color';
 import { deriveSize } from '$lib/interaction/geometry';
 import {
-  instrumentPolygonHover,
   instrumentPointHover,
-  instrumentLineHover
+  instrumentLineHover,
+  instrumentPolygonHover
 } from '$lib/interaction/hover';
 import {
   instrumentPointSelect,
@@ -31,7 +31,7 @@ import { getLayerGeometryType } from '$lib/utils/geojson';
  * @param map – The top-level MapLibre GL map instance.
  * @param layer – The CartoKit layer to add to the map.
  */
-export function addLayer(map: Map, layer: CartoKitLayer): void {
+export const addLayer = (map: Map, layer: CartoKitLayer): void => {
   switch (layer.type) {
     case 'Point': {
       const fillProperties = layer.style.fill
@@ -61,82 +61,6 @@ export function addLayer(map: Map, layer: CartoKitLayer): void {
 
       instrumentPointHover(map, layer.id);
       instrumentPointSelect(map, layer.id);
-      break;
-    }
-    case 'Line': {
-      map.addLayer({
-        id: layer.id,
-        source: layer.id,
-        type: 'line',
-        paint: {
-          'line-color': layer.style.stroke.color,
-          'line-width': layer.style.stroke.width,
-          'line-opacity': layer.style.stroke.opacity
-        }
-      });
-
-      instrumentLineHover(map, layer.id);
-      instrumentLineSelect(map, layer.id);
-      break;
-    }
-    case 'Fill': {
-      if (layer.style.fill) {
-        map.addLayer({
-          id: layer.id,
-          source: layer.id,
-          type: 'fill',
-          paint: {
-            'fill-color': layer.style.fill.color,
-            'fill-opacity': layer.style.fill.opacity
-          }
-        });
-      }
-
-      // Add a separate layer for the stroke, if a stroke exists.
-      if (layer.style.stroke) {
-        map.addLayer({
-          id: `${layer.id}-stroke`,
-          source: layer.id,
-          type: 'line',
-          paint: {
-            'line-color': layer.style.stroke.color,
-            'line-width': layer.style.stroke.width,
-            'line-opacity': layer.style.stroke.opacity
-          }
-        });
-      }
-
-      instrumentPolygonHover(map, layer.id);
-      instrumentPolygonSelect(map, layer.id);
-      break;
-    }
-    case 'Choropleth': {
-      map.addLayer({
-        id: layer.id,
-        source: layer.id,
-        type: 'fill',
-        paint: {
-          'fill-color': deriveColorScale(layer),
-          'fill-opacity': layer.style.fill.opacity
-        }
-      });
-
-      // Add a separate layer for the stroke.
-      if (layer.style.stroke) {
-        map.addLayer({
-          id: `${layer.id}-stroke`,
-          source: layer.id,
-          type: 'line',
-          paint: {
-            'line-color': layer.style.stroke.color,
-            'line-width': layer.style.stroke.width,
-            'line-opacity': layer.style.stroke.opacity
-          }
-        });
-      }
-
-      instrumentPolygonHover(map, layer.id);
-      instrumentPolygonSelect(map, layer.id);
       break;
     }
     case 'Proportional Symbol': {
@@ -221,8 +145,84 @@ export function addLayer(map: Map, layer: CartoKitLayer): void {
       instrumentPolygonSelect(map, `${layer.id}-outlines`);
       break;
     }
+    case 'Line': {
+      map.addLayer({
+        id: layer.id,
+        source: layer.id,
+        type: 'line',
+        paint: {
+          'line-color': layer.style.stroke.color,
+          'line-width': layer.style.stroke.width,
+          'line-opacity': layer.style.stroke.opacity
+        }
+      });
+
+      instrumentLineHover(map, layer.id);
+      instrumentLineSelect(map, layer.id);
+      break;
+    }
+    case 'Fill': {
+      if (layer.style.fill) {
+        map.addLayer({
+          id: layer.id,
+          source: layer.id,
+          type: 'fill',
+          paint: {
+            'fill-color': layer.style.fill.color,
+            'fill-opacity': layer.style.fill.opacity
+          }
+        });
+      }
+
+      // Add a separate layer for the stroke, if a stroke exists.
+      if (layer.style.stroke) {
+        map.addLayer({
+          id: `${layer.id}-stroke`,
+          source: layer.id,
+          type: 'line',
+          paint: {
+            'line-color': layer.style.stroke.color,
+            'line-width': layer.style.stroke.width,
+            'line-opacity': layer.style.stroke.opacity
+          }
+        });
+      }
+
+      instrumentPolygonHover(map, layer.id);
+      instrumentPolygonSelect(map, layer.id);
+      break;
+    }
+    case 'Choropleth': {
+      map.addLayer({
+        id: layer.id,
+        source: layer.id,
+        type: 'fill',
+        paint: {
+          'fill-color': deriveColorScale(layer),
+          'fill-opacity': layer.style.fill.opacity
+        }
+      });
+
+      // Add a separate layer for the stroke.
+      if (layer.style.stroke) {
+        map.addLayer({
+          id: `${layer.id}-stroke`,
+          source: layer.id,
+          type: 'line',
+          paint: {
+            'line-color': layer.style.stroke.color,
+            'line-width': layer.style.stroke.width,
+            'line-opacity': layer.style.stroke.opacity
+          }
+        });
+      }
+
+      instrumentPolygonHover(map, layer.id);
+      instrumentPolygonSelect(map, layer.id);
+      break;
+    }
   }
-}
+};
 
 /**
  * Generate a CartoKitLayer for a given GeoJSON dataset, using the dataset's

--- a/src/lib/interaction/map-type.ts
+++ b/src/lib/interaction/map-type.ts
@@ -11,13 +11,13 @@ import {
 import { addLayer } from '$lib/interaction/layer';
 import { listeners, type LayerListeners } from '$lib/stores/listeners';
 import type {
-  CartoKitFillLayer,
-  CartoKitChoroplethLayer,
-  CartoKitProportionalSymbolLayer,
-  CartoKitDotDensityLayer,
   CartoKitLayer,
   CartoKitPointLayer,
-  CartoKitLineLayer
+  CartoKitProportionalSymbolLayer,
+  CartoKitDotDensityLayer,
+  CartoKitLineLayer,
+  CartoKitFillLayer,
+  CartoKitChoroplethLayer
 } from '$lib/types/CartoKitLayer';
 import type { MapType } from '$lib/types/map-types';
 import { randomColor } from '$lib/utils/color';
@@ -77,6 +77,14 @@ export const transitionMapType = ({
       ({ redraw, targetLayer } = transitionToPoint(map, layer));
       break;
     }
+    case 'Proportional Symbol': {
+      ({ redraw, targetLayer } = transitionToProportionalSymbol(map, layer));
+      break;
+    }
+    case 'Dot Density': {
+      ({ redraw, targetLayer } = transitionToDotDensity(layer));
+      break;
+    }
     case 'Line': {
       ({ redraw, targetLayer } = transitionToLine(map, layer));
       break;
@@ -87,14 +95,6 @@ export const transitionMapType = ({
     }
     case 'Choropleth': {
       ({ redraw, targetLayer } = transitionToChoropleth(map, layer));
-      break;
-    }
-    case 'Proportional Symbol': {
-      ({ redraw, targetLayer } = transitionToProportionalSymbol(map, layer));
-      break;
-    }
-    case 'Dot Density': {
-      ({ redraw, targetLayer } = transitionToDotDensity(layer));
       break;
     }
   }
@@ -172,6 +172,49 @@ const transitionToPoint = (
         targetLayer: layer,
         redraw: false
       };
+    case 'Proportional Symbol': {
+      const targetLayer: CartoKitPointLayer = {
+        ...layer,
+        type: 'Point',
+        style: {
+          ...layer.style,
+          size: DEFAULT_RADIUS
+        }
+      };
+
+      // Update the circle-radius of the existing layer. All other paint
+      // properties should remain unchanged.
+      map.setPaintProperty(layer.id, 'circle-radius', DEFAULT_RADIUS);
+
+      return {
+        targetLayer,
+        redraw: false
+      };
+    }
+    case 'Dot Density': {
+      const targetLayer: CartoKitPointLayer = {
+        id: layer.id,
+        displayName: layer.displayName,
+        type: 'Point',
+        data: {
+          ...layer.data,
+          geoJSON: deriveCentroids(layer.data.rawGeoJSON.features),
+          transformations: [
+            ...layer.data.transformations,
+            transformGeometryToCentroids()
+          ]
+        },
+        style: {
+          ...layer.style,
+          size: layer.style.dots.size
+        }
+      };
+
+      return {
+        targetLayer,
+        redraw: true
+      };
+    }
     case 'Line': {
       const targetLayer: CartoKitPointLayer = {
         id: layer.id,
@@ -255,416 +298,6 @@ const transitionToPoint = (
         redraw: true
       };
     }
-    case 'Proportional Symbol': {
-      const targetLayer: CartoKitPointLayer = {
-        ...layer,
-        type: 'Point',
-        style: {
-          ...layer.style,
-          size: DEFAULT_RADIUS
-        }
-      };
-
-      // Update the circle-radius of the existing layer. All other paint
-      // properties should remain unchanged.
-      map.setPaintProperty(layer.id, 'circle-radius', DEFAULT_RADIUS);
-
-      return {
-        targetLayer,
-        redraw: false
-      };
-    }
-    case 'Dot Density': {
-      const targetLayer: CartoKitPointLayer = {
-        id: layer.id,
-        displayName: layer.displayName,
-        type: 'Point',
-        data: {
-          ...layer.data,
-          geoJSON: deriveCentroids(layer.data.rawGeoJSON.features),
-          transformations: [
-            ...layer.data.transformations,
-            transformGeometryToCentroids()
-          ]
-        },
-        style: {
-          ...layer.style,
-          size: layer.style.dots.size
-        }
-      };
-
-      return {
-        targetLayer,
-        redraw: true
-      };
-    }
-  }
-};
-
-const transitionToLine = (
-  map: Map,
-  layer: CartoKitLayer
-): TransitionMapTypeReturnValue => {
-  switch (layer.type) {
-    case 'Line':
-      return {
-        targetLayer: layer,
-        redraw: false
-      };
-    case 'Point':
-    case 'Proportional Symbol': {
-      const rawGeometryType = getLayerGeometryType(layer.data.rawGeoJSON);
-
-      if (
-        rawGeometryType !== 'LineString' &&
-        rawGeometryType !== 'MultiLineString'
-      ) {
-        const error = generateUnsupportedTransitionError(
-          rawGeometryType,
-          'LineString'
-        );
-        throw error;
-      }
-
-      const targetLayer: CartoKitLineLayer = {
-        id: layer.id,
-        displayName: layer.displayName,
-        type: 'Line',
-        data: {
-          ...layer.data,
-          geoJSON: layer.data.rawGeoJSON
-        },
-        style: {
-          stroke: layer.style.stroke ?? {
-            color: DEFAULT_STROKE,
-            width: DEFAULT_STROKE_WIDTH,
-            opacity: DEFAULT_OPACITY
-          }
-        }
-      };
-
-      return {
-        targetLayer,
-        redraw: true
-      };
-    }
-    case 'Dot Density':
-    case 'Fill':
-    case 'Choropleth': {
-      const geometryType = getLayerGeometryType(layer.data.geoJSON);
-      const error = generateUnsupportedTransitionError(
-        geometryType,
-        'LineString'
-      );
-
-      throw error;
-    }
-  }
-};
-
-/**
- * Transition a layer to a polygon fill layer.
- *
- * @param map — The top-level MapLibre GL map instance.
- * @param layer — The CartoKit layer to transition.
- *
- * @returns — The transitioned CartoKitFillLayer.
- */
-const transitionToFill = (
-  map: Map,
-  layer: CartoKitLayer
-): TransitionMapTypeReturnValue => {
-  switch (layer.type) {
-    case 'Fill':
-      return {
-        targetLayer: layer,
-        redraw: false
-      };
-    case 'Point': {
-      const rawGeometryType = getLayerGeometryType(layer.data.rawGeoJSON);
-
-      if (rawGeometryType !== 'Polygon' && rawGeometryType !== 'MultiPolygon') {
-        generateUnsupportedTransitionError(rawGeometryType, 'Polygon');
-      }
-
-      const targetLayer: CartoKitFillLayer = {
-        id: layer.id,
-        displayName: layer.displayName,
-        type: 'Fill',
-        data: {
-          ...layer.data,
-          geoJSON: layer.data.rawGeoJSON
-        },
-        style: {
-          fill: layer.style.fill,
-          stroke: layer.style.stroke
-        }
-      };
-
-      return {
-        targetLayer,
-        redraw: true
-      };
-    }
-    case 'Line': {
-      const rawGeometryType = getLayerGeometryType(layer.data.rawGeoJSON);
-      const error = generateUnsupportedTransitionError(
-        rawGeometryType,
-        'Polygon'
-      );
-
-      throw error;
-    }
-    case 'Choropleth': {
-      const colors = layer.style.fill.scheme[layer.style.fill.count];
-      const color = colors.at(-1) ?? randomColor();
-
-      const targetLayer: CartoKitFillLayer = {
-        id: layer.id,
-        displayName: layer.displayName,
-        type: 'Fill',
-        data: layer.data,
-        style: {
-          fill: {
-            color,
-            opacity: layer.style.fill.opacity
-          },
-          stroke: layer.style.stroke
-        }
-      };
-
-      // Update the fill-color of the existing layer. All other paint properties
-      // should remain unchanged.
-      map.setPaintProperty(layer.id, 'fill-color', color);
-
-      return {
-        targetLayer,
-        redraw: false
-      };
-    }
-    case 'Proportional Symbol': {
-      const rawGeometryType = getLayerGeometryType(layer.data.rawGeoJSON);
-
-      if (rawGeometryType !== 'Polygon' && rawGeometryType !== 'MultiPolygon') {
-        generateUnsupportedTransitionError(rawGeometryType, 'Polygon');
-      }
-
-      const targetLayer: CartoKitFillLayer = {
-        id: layer.id,
-        displayName: layer.displayName,
-        type: 'Fill',
-        data: {
-          ...layer.data,
-          geoJSON: layer.data.rawGeoJSON
-        },
-        style: {
-          fill: layer.style.fill,
-          stroke: layer.style.stroke
-        }
-      };
-
-      return {
-        targetLayer,
-        redraw: true
-      };
-    }
-    case 'Dot Density': {
-      const targetLayer: CartoKitFillLayer = {
-        id: layer.id,
-        displayName: layer.displayName,
-        type: 'Fill',
-        data: {
-          ...layer.data,
-          geoJSON: layer.data.rawGeoJSON
-        },
-        style: {
-          fill: layer.style.fill,
-          stroke: layer.style.stroke
-        }
-      };
-
-      return {
-        targetLayer,
-        redraw: true
-      };
-    }
-  }
-};
-
-/**
- * Transition a layer to a choropleth layer.
- *
- * @param map — The top-level MapLibre GL map instance.
- * @param layer — The CartoKit layer to transition.
- *
- * @returns – The transitioned CartoKitChoroplethLayer.
- */
-const transitionToChoropleth = (
-  map: Map,
-  layer: CartoKitLayer
-): TransitionMapTypeReturnValue => {
-  switch (layer.type) {
-    case 'Choropleth': {
-      return {
-        targetLayer: layer,
-        redraw: false
-      };
-    }
-    case 'Point': {
-      const rawGeometryType = getLayerGeometryType(layer.data.rawGeoJSON);
-
-      if (rawGeometryType !== 'Polygon' && rawGeometryType !== 'MultiPolygon') {
-        generateUnsupportedTransitionError(rawGeometryType, 'Polygon');
-      }
-
-      const attribute = selectNumericAttribute(layer.data.geoJSON.features);
-
-      const targetLayer: CartoKitChoroplethLayer = {
-        id: layer.id,
-        displayName: layer.displayName,
-        type: 'Choropleth',
-        data: {
-          ...layer.data,
-          geoJSON: layer.data.rawGeoJSON
-        },
-        style: {
-          fill: {
-            attribute,
-            scale: DEFAULT_SCALE,
-            scheme: DEFAULT_SCHEME,
-            count: DEFAULT_COUNT,
-            thresholds: DEFAULT_THRESHOLDS(
-              attribute,
-              layer.data.geoJSON.features
-            ),
-            opacity: layer.style.fill?.opacity ?? DEFAULT_OPACITY
-          },
-          stroke: layer.style.stroke
-        }
-      };
-
-      return {
-        targetLayer,
-        redraw: true
-      };
-    }
-    case 'Line': {
-      const rawGeometryType = getLayerGeometryType(layer.data.rawGeoJSON);
-      const error = generateUnsupportedTransitionError(
-        rawGeometryType,
-        'Polygon'
-      );
-
-      throw error;
-    }
-    case 'Fill': {
-      const attribute = selectNumericAttribute(layer.data.geoJSON.features);
-
-      const targetLayer: CartoKitChoroplethLayer = {
-        id: layer.id,
-        displayName: layer.displayName,
-        type: 'Choropleth',
-        data: layer.data,
-        style: {
-          fill: {
-            attribute,
-            scale: DEFAULT_SCALE,
-            scheme: DEFAULT_SCHEME,
-            count: DEFAULT_COUNT,
-            thresholds: DEFAULT_THRESHOLDS(
-              attribute,
-              layer.data.geoJSON.features
-            ),
-            opacity: layer.style.fill?.opacity ?? DEFAULT_OPACITY
-          },
-          stroke: layer.style.stroke
-        }
-      };
-
-      // Set the fill-color of polygons based on the choropleth color scale.
-      map.setPaintProperty(
-        layer.id,
-        'fill-color',
-        deriveColorScale(targetLayer)
-      );
-
-      // If the Fill layer we're transitioning from had no fill, set the opacity
-      // to the default to ensure the fill is visible.
-      if (!layer.style.fill?.opacity) {
-        map.setPaintProperty(layer.id, 'fill-opacity', DEFAULT_OPACITY);
-      }
-
-      return {
-        targetLayer,
-        redraw: false
-      };
-    }
-    case 'Proportional Symbol': {
-      const rawGeometryType = getLayerGeometryType(layer.data.rawGeoJSON);
-
-      if (rawGeometryType !== 'Polygon' && rawGeometryType !== 'MultiPolygon') {
-        generateUnsupportedTransitionError(rawGeometryType, 'Polygon');
-      }
-
-      const targetLayer: CartoKitChoroplethLayer = {
-        id: layer.id,
-        displayName: layer.displayName,
-        type: 'Choropleth',
-        data: {
-          ...layer.data,
-          geoJSON: layer.data.rawGeoJSON
-        },
-        style: {
-          fill: {
-            attribute: layer.style.size.attribute,
-            scale: DEFAULT_SCALE,
-            scheme: DEFAULT_SCHEME,
-            count: DEFAULT_COUNT,
-            thresholds: DEFAULT_THRESHOLDS(
-              layer.style.size.attribute,
-              layer.data.geoJSON.features
-            ),
-            opacity: layer.style.fill?.opacity ?? DEFAULT_OPACITY
-          },
-          stroke: layer.style.stroke
-        }
-      };
-
-      return {
-        targetLayer,
-        redraw: true
-      };
-    }
-    case 'Dot Density': {
-      const targetLayer: CartoKitChoroplethLayer = {
-        id: layer.id,
-        displayName: layer.displayName,
-        type: 'Choropleth',
-        data: {
-          ...layer.data,
-          geoJSON: layer.data.rawGeoJSON
-        },
-        style: {
-          fill: {
-            attribute: layer.style.dots.attribute,
-            scale: DEFAULT_SCALE,
-            scheme: DEFAULT_SCHEME,
-            count: DEFAULT_COUNT,
-            thresholds: DEFAULT_THRESHOLDS(
-              layer.style.dots.attribute,
-              layer.data.geoJSON.features
-            ),
-            opacity: layer.style.fill?.opacity ?? DEFAULT_OPACITY
-          },
-          stroke: layer.style.stroke
-        }
-      };
-
-      return {
-        targetLayer,
-        redraw: true
-      };
-    }
   }
 };
 
@@ -682,11 +315,6 @@ const transitionToProportionalSymbol = (
   const features = layer.data.geoJSON.features;
 
   switch (layer.type) {
-    case 'Proportional Symbol':
-      return {
-        targetLayer: layer,
-        redraw: false
-      };
     case 'Point': {
       const targetLayer: CartoKitProportionalSymbolLayer = {
         id: layer.id,
@@ -711,6 +339,40 @@ const transitionToProportionalSymbol = (
       return {
         targetLayer,
         redraw: false
+      };
+    }
+    case 'Proportional Symbol':
+      return {
+        targetLayer: layer,
+        redraw: false
+      };
+    case 'Dot Density': {
+      const targetLayer: CartoKitProportionalSymbolLayer = {
+        id: layer.id,
+        displayName: layer.displayName,
+        type: 'Proportional Symbol',
+        data: {
+          ...layer.data,
+          geoJSON: deriveCentroids(layer.data.rawGeoJSON.features),
+          transformations: [
+            ...layer.data.transformations,
+            transformGeometryToCentroids()
+          ]
+        },
+        style: {
+          size: {
+            attribute: layer.style.dots.attribute,
+            min: DEFAULT_MIN_SIZE,
+            max: DEFAULT_MAX_SIZE
+          },
+          fill: layer.style.fill,
+          stroke: layer.style.stroke
+        }
+      };
+
+      return {
+        targetLayer,
+        redraw: true
       };
     }
     case 'Line': {
@@ -808,35 +470,6 @@ const transitionToProportionalSymbol = (
         redraw: true
       };
     }
-    case 'Dot Density': {
-      const targetLayer: CartoKitProportionalSymbolLayer = {
-        id: layer.id,
-        displayName: layer.displayName,
-        type: 'Proportional Symbol',
-        data: {
-          ...layer.data,
-          geoJSON: deriveCentroids(layer.data.rawGeoJSON.features),
-          transformations: [
-            ...layer.data.transformations,
-            transformGeometryToCentroids()
-          ]
-        },
-        style: {
-          size: {
-            attribute: layer.style.dots.attribute,
-            min: DEFAULT_MIN_SIZE,
-            max: DEFAULT_MAX_SIZE
-          },
-          fill: layer.style.fill,
-          stroke: layer.style.stroke
-        }
-      };
-
-      return {
-        targetLayer,
-        redraw: true
-      };
-    }
   }
 };
 
@@ -851,11 +484,6 @@ const transitionToDotDensity = (
   layer: CartoKitLayer
 ): TransitionMapTypeReturnValue => {
   switch (layer.type) {
-    case 'Dot Density':
-      return {
-        targetLayer: layer,
-        redraw: false
-      };
     case 'Point': {
       const rawGeometryType = getLayerGeometryType(layer.data.rawGeoJSON);
 
@@ -899,6 +527,57 @@ const transitionToDotDensity = (
         redraw: true
       };
     }
+    case 'Proportional Symbol': {
+      const rawGeometryType = getLayerGeometryType(layer.data.rawGeoJSON);
+
+      if (rawGeometryType !== 'Polygon' && rawGeometryType !== 'MultiPolygon') {
+        generateUnsupportedTransitionError(rawGeometryType, 'Polygon');
+      }
+
+      const features = layer.data.rawGeoJSON.features;
+      const attribute = layer.style.size.attribute;
+      const dotValue = deriveDotDensityStartingValue(
+        features,
+        layer.style.size.attribute
+      );
+
+      const targetLayer: CartoKitDotDensityLayer = {
+        id: layer.id,
+        displayName: layer.displayName,
+        type: 'Dot Density',
+        data: {
+          ...layer.data,
+          geoJSON: generateDotDensityPoints({
+            features,
+            attribute,
+            value: dotValue
+          }),
+          transformations: [
+            ...layer.data.transformations,
+            transformDotDensity(attribute, dotValue)
+          ]
+        },
+        style: {
+          dots: {
+            attribute,
+            size: 1,
+            value: dotValue
+          },
+          fill: layer.style.fill,
+          stroke: layer.style.stroke
+        }
+      };
+
+      return {
+        targetLayer,
+        redraw: true
+      };
+    }
+    case 'Dot Density':
+      return {
+        targetLayer: layer,
+        redraw: false
+      };
     case 'Line': {
       const rawGeometryType = getLayerGeometryType(layer.data.rawGeoJSON);
       const error = generateUnsupportedTransitionError(
@@ -987,42 +666,107 @@ const transitionToDotDensity = (
         redraw: true
       };
     }
+  }
+};
+
+/**
+ * Transition a layer to a line layer.
+ *
+ * @param map – The top-level MapLibre GL map instance.
+ * @param layer – The CartoKit layer to transition.
+ *
+ * @returns – The transitioned CartoKitLineLayer.
+ */
+const transitionToLine = (
+  _map: Map,
+  layer: CartoKitLayer
+): TransitionMapTypeReturnValue => {
+  switch (layer.type) {
+    case 'Line':
+      return {
+        targetLayer: layer,
+        redraw: false
+      };
+    case 'Point':
     case 'Proportional Symbol': {
+      const rawGeometryType = getLayerGeometryType(layer.data.rawGeoJSON);
+
+      if (
+        rawGeometryType !== 'LineString' &&
+        rawGeometryType !== 'MultiLineString'
+      ) {
+        const error = generateUnsupportedTransitionError(
+          rawGeometryType,
+          'LineString'
+        );
+        throw error;
+      }
+
+      const targetLayer: CartoKitLineLayer = {
+        id: layer.id,
+        displayName: layer.displayName,
+        type: 'Line',
+        data: {
+          ...layer.data,
+          geoJSON: layer.data.rawGeoJSON
+        },
+        style: {
+          stroke: layer.style.stroke ?? {
+            color: DEFAULT_STROKE,
+            width: DEFAULT_STROKE_WIDTH,
+            opacity: DEFAULT_OPACITY
+          }
+        }
+      };
+
+      return {
+        targetLayer,
+        redraw: true
+      };
+    }
+    case 'Dot Density':
+    case 'Fill':
+    case 'Choropleth': {
+      const geometryType = getLayerGeometryType(layer.data.geoJSON);
+      const error = generateUnsupportedTransitionError(
+        geometryType,
+        'LineString'
+      );
+
+      throw error;
+    }
+  }
+};
+
+/**
+ * Transition a layer to a polygon fill layer.
+ *
+ * @param map — The top-level MapLibre GL map instance.
+ * @param layer — The CartoKit layer to transition.
+ *
+ * @returns — The transitioned CartoKitFillLayer.
+ */
+const transitionToFill = (
+  map: Map,
+  layer: CartoKitLayer
+): TransitionMapTypeReturnValue => {
+  switch (layer.type) {
+    case 'Point': {
       const rawGeometryType = getLayerGeometryType(layer.data.rawGeoJSON);
 
       if (rawGeometryType !== 'Polygon' && rawGeometryType !== 'MultiPolygon') {
         generateUnsupportedTransitionError(rawGeometryType, 'Polygon');
       }
 
-      const features = layer.data.rawGeoJSON.features;
-      const attribute = layer.style.size.attribute;
-      const dotValue = deriveDotDensityStartingValue(
-        features,
-        layer.style.size.attribute
-      );
-
-      const targetLayer: CartoKitDotDensityLayer = {
+      const targetLayer: CartoKitFillLayer = {
         id: layer.id,
         displayName: layer.displayName,
-        type: 'Dot Density',
+        type: 'Fill',
         data: {
           ...layer.data,
-          geoJSON: generateDotDensityPoints({
-            features,
-            attribute,
-            value: dotValue
-          }),
-          transformations: [
-            ...layer.data.transformations,
-            transformDotDensity(attribute, dotValue)
-          ]
+          geoJSON: layer.data.rawGeoJSON
         },
         style: {
-          dots: {
-            attribute,
-            size: 1,
-            value: dotValue
-          },
           fill: layer.style.fill,
           stroke: layer.style.stroke
         }
@@ -1031,6 +775,270 @@ const transitionToDotDensity = (
       return {
         targetLayer,
         redraw: true
+      };
+    }
+    case 'Proportional Symbol': {
+      const rawGeometryType = getLayerGeometryType(layer.data.rawGeoJSON);
+
+      if (rawGeometryType !== 'Polygon' && rawGeometryType !== 'MultiPolygon') {
+        generateUnsupportedTransitionError(rawGeometryType, 'Polygon');
+      }
+
+      const targetLayer: CartoKitFillLayer = {
+        id: layer.id,
+        displayName: layer.displayName,
+        type: 'Fill',
+        data: {
+          ...layer.data,
+          geoJSON: layer.data.rawGeoJSON
+        },
+        style: {
+          fill: layer.style.fill,
+          stroke: layer.style.stroke
+        }
+      };
+
+      return {
+        targetLayer,
+        redraw: true
+      };
+    }
+    case 'Dot Density': {
+      const targetLayer: CartoKitFillLayer = {
+        id: layer.id,
+        displayName: layer.displayName,
+        type: 'Fill',
+        data: {
+          ...layer.data,
+          geoJSON: layer.data.rawGeoJSON
+        },
+        style: {
+          fill: layer.style.fill,
+          stroke: layer.style.stroke
+        }
+      };
+
+      return {
+        targetLayer,
+        redraw: true
+      };
+    }
+    case 'Line': {
+      const rawGeometryType = getLayerGeometryType(layer.data.rawGeoJSON);
+      const error = generateUnsupportedTransitionError(
+        rawGeometryType,
+        'Polygon'
+      );
+
+      throw error;
+    }
+    case 'Fill':
+      return {
+        targetLayer: layer,
+        redraw: false
+      };
+    case 'Choropleth': {
+      const colors = layer.style.fill.scheme[layer.style.fill.count];
+      const color = colors.at(-1) ?? randomColor();
+
+      const targetLayer: CartoKitFillLayer = {
+        id: layer.id,
+        displayName: layer.displayName,
+        type: 'Fill',
+        data: layer.data,
+        style: {
+          fill: {
+            color,
+            opacity: layer.style.fill.opacity
+          },
+          stroke: layer.style.stroke
+        }
+      };
+
+      // Update the fill-color of the existing layer. All other paint properties
+      // should remain unchanged.
+      map.setPaintProperty(layer.id, 'fill-color', color);
+
+      return {
+        targetLayer,
+        redraw: false
+      };
+    }
+  }
+};
+
+/**
+ * Transition a layer to a choropleth layer.
+ *
+ * @param map — The top-level MapLibre GL map instance.
+ * @param layer — The CartoKit layer to transition.
+ *
+ * @returns – The transitioned CartoKitChoroplethLayer.
+ */
+const transitionToChoropleth = (
+  map: Map,
+  layer: CartoKitLayer
+): TransitionMapTypeReturnValue => {
+  switch (layer.type) {
+    case 'Point': {
+      const rawGeometryType = getLayerGeometryType(layer.data.rawGeoJSON);
+
+      if (rawGeometryType !== 'Polygon' && rawGeometryType !== 'MultiPolygon') {
+        generateUnsupportedTransitionError(rawGeometryType, 'Polygon');
+      }
+
+      const attribute = selectNumericAttribute(layer.data.geoJSON.features);
+
+      const targetLayer: CartoKitChoroplethLayer = {
+        id: layer.id,
+        displayName: layer.displayName,
+        type: 'Choropleth',
+        data: {
+          ...layer.data,
+          geoJSON: layer.data.rawGeoJSON
+        },
+        style: {
+          fill: {
+            attribute,
+            scale: DEFAULT_SCALE,
+            scheme: DEFAULT_SCHEME,
+            count: DEFAULT_COUNT,
+            thresholds: DEFAULT_THRESHOLDS(
+              attribute,
+              layer.data.geoJSON.features
+            ),
+            opacity: layer.style.fill?.opacity ?? DEFAULT_OPACITY
+          },
+          stroke: layer.style.stroke
+        }
+      };
+
+      return {
+        targetLayer,
+        redraw: true
+      };
+    }
+    case 'Proportional Symbol': {
+      const rawGeometryType = getLayerGeometryType(layer.data.rawGeoJSON);
+
+      if (rawGeometryType !== 'Polygon' && rawGeometryType !== 'MultiPolygon') {
+        generateUnsupportedTransitionError(rawGeometryType, 'Polygon');
+      }
+
+      const targetLayer: CartoKitChoroplethLayer = {
+        id: layer.id,
+        displayName: layer.displayName,
+        type: 'Choropleth',
+        data: {
+          ...layer.data,
+          geoJSON: layer.data.rawGeoJSON
+        },
+        style: {
+          fill: {
+            attribute: layer.style.size.attribute,
+            scale: DEFAULT_SCALE,
+            scheme: DEFAULT_SCHEME,
+            count: DEFAULT_COUNT,
+            thresholds: DEFAULT_THRESHOLDS(
+              layer.style.size.attribute,
+              layer.data.geoJSON.features
+            ),
+            opacity: layer.style.fill?.opacity ?? DEFAULT_OPACITY
+          },
+          stroke: layer.style.stroke
+        }
+      };
+
+      return {
+        targetLayer,
+        redraw: true
+      };
+    }
+    case 'Dot Density': {
+      const targetLayer: CartoKitChoroplethLayer = {
+        id: layer.id,
+        displayName: layer.displayName,
+        type: 'Choropleth',
+        data: {
+          ...layer.data,
+          geoJSON: layer.data.rawGeoJSON
+        },
+        style: {
+          fill: {
+            attribute: layer.style.dots.attribute,
+            scale: DEFAULT_SCALE,
+            scheme: DEFAULT_SCHEME,
+            count: DEFAULT_COUNT,
+            thresholds: DEFAULT_THRESHOLDS(
+              layer.style.dots.attribute,
+              layer.data.geoJSON.features
+            ),
+            opacity: layer.style.fill?.opacity ?? DEFAULT_OPACITY
+          },
+          stroke: layer.style.stroke
+        }
+      };
+
+      return {
+        targetLayer,
+        redraw: true
+      };
+    }
+    case 'Line': {
+      const rawGeometryType = getLayerGeometryType(layer.data.rawGeoJSON);
+      const error = generateUnsupportedTransitionError(
+        rawGeometryType,
+        'Polygon'
+      );
+
+      throw error;
+    }
+    case 'Fill': {
+      const attribute = selectNumericAttribute(layer.data.geoJSON.features);
+
+      const targetLayer: CartoKitChoroplethLayer = {
+        id: layer.id,
+        displayName: layer.displayName,
+        type: 'Choropleth',
+        data: layer.data,
+        style: {
+          fill: {
+            attribute,
+            scale: DEFAULT_SCALE,
+            scheme: DEFAULT_SCHEME,
+            count: DEFAULT_COUNT,
+            thresholds: DEFAULT_THRESHOLDS(
+              attribute,
+              layer.data.geoJSON.features
+            ),
+            opacity: layer.style.fill?.opacity ?? DEFAULT_OPACITY
+          },
+          stroke: layer.style.stroke
+        }
+      };
+
+      // Set the fill-color of polygons based on the choropleth color scale.
+      map.setPaintProperty(
+        layer.id,
+        'fill-color',
+        deriveColorScale(targetLayer)
+      );
+
+      // If the Fill layer we're transitioning from had no fill, set the opacity
+      // to the default to ensure the fill is visible.
+      if (!layer.style.fill?.opacity) {
+        map.setPaintProperty(layer.id, 'fill-opacity', DEFAULT_OPACITY);
+      }
+
+      return {
+        targetLayer,
+        redraw: false
+      };
+    }
+    case 'Choropleth': {
+      return {
+        targetLayer: layer,
+        redraw: false
       };
     }
   }

--- a/src/lib/interaction/map-type.ts
+++ b/src/lib/interaction/map-type.ts
@@ -74,6 +74,10 @@ export const transitionMapType = ({
       ({ redraw, targetLayer } = transitionToPoint(map, layer));
       break;
     }
+    case 'Line': {
+      ({ redraw, targetLayer } = transitionToLine(map, layer));
+      break;
+    }
     case 'Fill': {
       ({ redraw, targetLayer } = transitionToFill(map, layer));
       break;
@@ -165,6 +169,13 @@ const transitionToPoint = (
         targetLayer: layer,
         redraw: false
       };
+    case 'Line': {
+      // TODO:
+      return {
+        targetLayer: layer,
+        redraw: false
+      };
+    }
     case 'Fill': {
       const targetLayer: CartoKitPointLayer = {
         id: layer.id,
@@ -266,6 +277,28 @@ const transitionToPoint = (
   }
 };
 
+const transitionToLine = (
+  map: Map,
+  layer: CartoKitLayer
+): TransitionMapTypeReturnValue => {
+  switch (layer.type) {
+    case 'Line':
+      return {
+        targetLayer: layer,
+        redraw: false
+      };
+    case 'Point':
+    case 'Proportional Symbol':
+    case 'Dot Density':
+      throwUnsupportedTransitionError('Point', 'LineString');
+      break;
+    case 'Fill':
+    case 'Choropleth':
+      throwUnsupportedTransitionError('Polygon', 'LineString');
+      break;
+  }
+};
+
 /**
  * Transition a layer to a polygon fill layer.
  *
@@ -279,12 +312,11 @@ const transitionToFill = (
   layer: CartoKitLayer
 ): TransitionMapTypeReturnValue => {
   switch (layer.type) {
-    case 'Fill': {
+    case 'Fill':
       return {
         targetLayer: layer,
         redraw: false
       };
-    }
     case 'Point': {
       const rawGeometryType = getLayerGeometryType(layer.data.rawGeoJSON);
 

--- a/src/lib/interaction/select.ts
+++ b/src/lib/interaction/select.ts
@@ -6,31 +6,6 @@ import { listeners } from '$lib/stores/listeners';
 import { selectedFeature } from '$lib/stores/selected-feature';
 
 /**
- * Add a selection indicator to a feature in a polygon layer.
- *
- * @param map – The top-level MapLibre GL map instance.
- * @param layerId — The id of the layer to instrument.
- */
-export function instrumentPolygonSelect(map: Map, layerId: string): void {
-  map.addLayer({
-    id: `${layerId}-select`,
-    type: 'line',
-    source: layerId,
-    paint: {
-      'line-color': '#A534FF',
-      'line-width': [
-        'case',
-        ['boolean', ['feature-state', 'selected'], false],
-        1,
-        0
-      ]
-    }
-  });
-
-  addSelectListeners(map, layerId);
-}
-
-/**
  * Add a selection indicator to a feature in a point layer.
  *
  * @param map – The top-level MapLibre GL map instance.
@@ -58,6 +33,57 @@ export function instrumentPointSelect(map: Map, layerId: string): void {
     '#A534FF',
     currentStrokeColor ?? 'transparent'
   ]);
+
+  addSelectListeners(map, layerId);
+}
+
+/**
+ * Add a selection indicator to a feature in a line layer.
+ *
+ * @param map – The top-level MapLibre GL map instance.
+ * @param layerId — The id of the layer to instrument.
+ */
+export function instrumentLineSelect(map: Map, layerId: string): void {
+  const currentStrokeWidth = map.getPaintProperty(layerId, 'line-width');
+  const currentStrokeColor = map.getPaintProperty(layerId, 'line-color');
+
+  map.setPaintProperty(layerId, 'line-width', [
+    'case',
+    ['boolean', ['feature-state', 'selected'], false],
+    1,
+    currentStrokeWidth ?? 0
+  ]);
+  map.setPaintProperty(layerId, 'line-color', [
+    'case',
+    ['boolean', ['feature-state', 'selected'], false],
+    '#A534FF',
+    currentStrokeColor ?? 'transparent'
+  ]);
+
+  addSelectListeners(map, layerId);
+}
+
+/**
+ * Add a selection indicator to a feature in a polygon layer.
+ *
+ * @param map – The top-level MapLibre GL map instance.
+ * @param layerId — The id of the layer to instrument.
+ */
+export function instrumentPolygonSelect(map: Map, layerId: string): void {
+  map.addLayer({
+    id: `${layerId}-select`,
+    type: 'line',
+    source: layerId,
+    paint: {
+      'line-color': '#A534FF',
+      'line-width': [
+        'case',
+        ['boolean', ['feature-state', 'selected'], false],
+        1,
+        0
+      ]
+    }
+  });
 
   addSelectListeners(map, layerId);
 }

--- a/src/lib/interaction/select.ts
+++ b/src/lib/interaction/select.ts
@@ -11,7 +11,7 @@ import { selectedFeature } from '$lib/stores/selected-feature';
  * @param map – The top-level MapLibre GL map instance.
  * @param layerId – The id of the layer to instrument.
  */
-export function instrumentPointSelect(map: Map, layerId: string): void {
+export const instrumentPointSelect = (map: Map, layerId: string): void => {
   const currentStrokeWidth = map.getPaintProperty(
     layerId,
     'circle-stroke-width'
@@ -35,7 +35,7 @@ export function instrumentPointSelect(map: Map, layerId: string): void {
   ]);
 
   addSelectListeners(map, layerId);
-}
+};
 
 /**
  * Add a selection indicator to a feature in a line layer.
@@ -43,7 +43,7 @@ export function instrumentPointSelect(map: Map, layerId: string): void {
  * @param map – The top-level MapLibre GL map instance.
  * @param layerId — The id of the layer to instrument.
  */
-export function instrumentLineSelect(map: Map, layerId: string): void {
+export const instrumentLineSelect = (map: Map, layerId: string): void => {
   const currentStrokeWidth = map.getPaintProperty(layerId, 'line-width');
   const currentStrokeColor = map.getPaintProperty(layerId, 'line-color');
 
@@ -61,7 +61,7 @@ export function instrumentLineSelect(map: Map, layerId: string): void {
   ]);
 
   addSelectListeners(map, layerId);
-}
+};
 
 /**
  * Add a selection indicator to a feature in a polygon layer.
@@ -69,7 +69,7 @@ export function instrumentLineSelect(map: Map, layerId: string): void {
  * @param map – The top-level MapLibre GL map instance.
  * @param layerId — The id of the layer to instrument.
  */
-export function instrumentPolygonSelect(map: Map, layerId: string): void {
+export const instrumentPolygonSelect = (map: Map, layerId: string): void => {
   map.addLayer({
     id: `${layerId}-select`,
     type: 'line',
@@ -86,7 +86,7 @@ export function instrumentPolygonSelect(map: Map, layerId: string): void {
   });
 
   addSelectListeners(map, layerId);
-}
+};
 
 /**
  * Wire up event listeners for select effects.
@@ -94,7 +94,7 @@ export function instrumentPolygonSelect(map: Map, layerId: string): void {
  * @param map – The top-level MapLibre GL map instance.
  * @param layerId – The id of the layer to instrument.
  */
-function addSelectListeners(map: Map, layerId: string) {
+const addSelectListeners = (map: Map, layerId: string) => {
   let selectedFeatureId: string | null = null;
 
   function onClick(event: MapLayerMouseEvent): void {
@@ -135,7 +135,7 @@ function addSelectListeners(map: Map, layerId: string) {
       click: onClick
     });
   });
-}
+};
 
 /**
  * A global event listener for deselecting features.
@@ -144,11 +144,11 @@ function addSelectListeners(map: Map, layerId: string) {
  * @param ir – The CartoKit IR.
  * @returns – deselectFeature, a callback to run when a map mouse event intersects no features.
  */
-export function onFeatureLeave(
+export const onFeatureLeave = (
   map: Map,
   { layers }: CartoKitIR
-): (event: MapMouseEvent) => void {
-  return function deselectFeature(event: MapMouseEvent) {
+): ((event: MapMouseEvent) => void) => {
+  return (event: MapMouseEvent): void => {
     const layerIds = Object.values(layers).map((layer) => {
       // For dot density layers, we need to deselect the outline layer.
       if (layer.type === 'Dot Density') {
@@ -183,4 +183,4 @@ export function onFeatureLeave(
       );
     }
   };
-}
+};

--- a/src/lib/interaction/update.ts
+++ b/src/lib/interaction/update.ts
@@ -18,7 +18,8 @@ import type {
   CartoKitChoroplethLayer,
   CartoKitProportionalSymbolLayer,
   CartoKitDotDensityLayer,
-  CartoKitPointLayer
+  CartoKitPointLayer,
+  CartoKitLineLayer
 } from '$lib/types/CartoKitLayer';
 import type { ColorScale, ColorScheme } from '$lib/types/color';
 import type { MapType } from '$lib/types/map-types';
@@ -70,6 +71,12 @@ interface FillOpacityUpdate extends LayerUpdate {
   payload: {
     opacity: number;
   };
+  layer:
+    | CartoKitPointLayer
+    | CartoKitFillLayer
+    | CartoKitChoroplethLayer
+    | CartoKitProportionalSymbolLayer
+    | CartoKitDotDensityLayer;
 }
 
 interface AddFillUpdate extends LayerUpdate {
@@ -321,7 +328,10 @@ export function dispatchLayerUpdate({
     }
     case 'fill-opacity': {
       ir.update((ir) => {
-        const lyr = ir.layers[layer.id];
+        const lyr = ir.layers[layer.id] as Exclude<
+          CartoKitLayer,
+          CartoKitLineLayer
+        >;
 
         if (lyr.style.fill) {
           lyr.style.fill.opacity = payload.opacity;
@@ -345,7 +355,11 @@ export function dispatchLayerUpdate({
     }
     case 'add-fill': {
       ir.update((ir) => {
-        const lyr = ir.layers[layer.id];
+        const lyr = ir.layers[layer.id] as
+          | CartoKitPointLayer
+          | CartoKitFillLayer
+          | CartoKitProportionalSymbolLayer
+          | CartoKitDotDensityLayer;
         lyr.style.fill = {
           color: DEFAULT_FILL,
           opacity: DEFAULT_OPACITY
@@ -353,7 +367,6 @@ export function dispatchLayerUpdate({
 
         switch (lyr.type) {
           case 'Fill':
-          case 'Choropleth':
             map.setPaintProperty(layer.id, 'fill-color', DEFAULT_FILL);
             map.setPaintProperty(layer.id, 'fill-opacity', DEFAULT_OPACITY);
             break;
@@ -371,7 +384,11 @@ export function dispatchLayerUpdate({
     }
     case 'remove-fill': {
       ir.update((ir) => {
-        const lyr = ir.layers[layer.id];
+        const lyr = ir.layers[layer.id] as
+          | CartoKitPointLayer
+          | CartoKitFillLayer
+          | CartoKitProportionalSymbolLayer
+          | CartoKitDotDensityLayer;
         lyr.style.fill = undefined;
 
         switch (lyr.type) {

--- a/src/lib/interaction/update.ts
+++ b/src/lib/interaction/update.ts
@@ -423,6 +423,9 @@ export function dispatchLayerUpdate({
                 payload.color
               );
               break;
+            case 'Line':
+              map.setPaintProperty(layer.id, 'line-color', payload.color);
+              break;
             case 'Point':
             case 'Proportional Symbol':
             case 'Dot Density':
@@ -455,6 +458,9 @@ export function dispatchLayerUpdate({
                 payload.strokeWidth
               );
               break;
+            case 'Line':
+              map.setPaintProperty(layer.id, 'line-width', payload.strokeWidth);
+              break;
             case 'Point':
             case 'Proportional Symbol':
             case 'Dot Density':
@@ -486,6 +492,9 @@ export function dispatchLayerUpdate({
                 'line-opacity',
                 payload.opacity
               );
+              break;
+            case 'Line':
+              map.setPaintProperty(layer.id, 'line-opacity', payload.opacity);
               break;
             case 'Point':
             case 'Proportional Symbol':
@@ -531,6 +540,8 @@ export function dispatchLayerUpdate({
               'line-opacity',
               DEFAULT_STROKE_OPACITY
             );
+            break;
+          case 'Line':
             break;
           case 'Point':
           case 'Proportional Symbol':

--- a/src/lib/interaction/update.ts
+++ b/src/lib/interaction/update.ts
@@ -14,12 +14,11 @@ import { ir } from '$lib/stores/ir';
 import { map as mapStore } from '$lib/stores/map';
 import type {
   CartoKitLayer,
-  CartoKitFillLayer,
-  CartoKitChoroplethLayer,
+  CartoKitPointLayer,
   CartoKitProportionalSymbolLayer,
   CartoKitDotDensityLayer,
-  CartoKitPointLayer,
-  CartoKitLineLayer
+  CartoKitFillLayer,
+  CartoKitChoroplethLayer
 } from '$lib/types/CartoKitLayer';
 import type { ColorScale, ColorScheme } from '$lib/types/color';
 import type { MapType } from '$lib/types/map-types';
@@ -49,9 +48,9 @@ interface AttributeUpdate extends LayerUpdate {
     attribute: string;
   };
   layer:
-    | CartoKitChoroplethLayer
     | CartoKitProportionalSymbolLayer
-    | CartoKitDotDensityLayer;
+    | CartoKitDotDensityLayer
+    | CartoKitChoroplethLayer;
 }
 
 interface FillUpdate extends LayerUpdate {
@@ -61,9 +60,9 @@ interface FillUpdate extends LayerUpdate {
   };
   layer:
     | CartoKitPointLayer
-    | CartoKitFillLayer
     | CartoKitProportionalSymbolLayer
-    | CartoKitDotDensityLayer;
+    | CartoKitDotDensityLayer
+    | CartoKitFillLayer;
 }
 
 interface FillOpacityUpdate extends LayerUpdate {
@@ -73,10 +72,10 @@ interface FillOpacityUpdate extends LayerUpdate {
   };
   layer:
     | CartoKitPointLayer
-    | CartoKitFillLayer
-    | CartoKitChoroplethLayer
     | CartoKitProportionalSymbolLayer
-    | CartoKitDotDensityLayer;
+    | CartoKitDotDensityLayer
+    | CartoKitFillLayer
+    | CartoKitChoroplethLayer;
 }
 
 interface AddFillUpdate extends LayerUpdate {
@@ -84,9 +83,9 @@ interface AddFillUpdate extends LayerUpdate {
   payload: Record<string, never>;
   layer:
     | CartoKitPointLayer
-    | CartoKitFillLayer
     | CartoKitProportionalSymbolLayer
-    | CartoKitDotDensityLayer;
+    | CartoKitDotDensityLayer
+    | CartoKitFillLayer;
 }
 
 interface RemoveFillUpdate extends LayerUpdate {
@@ -94,9 +93,9 @@ interface RemoveFillUpdate extends LayerUpdate {
   payload: Record<string, never>;
   layer:
     | CartoKitPointLayer
-    | CartoKitFillLayer
     | CartoKitProportionalSymbolLayer
-    | CartoKitDotDensityLayer;
+    | CartoKitDotDensityLayer
+    | CartoKitFillLayer;
 }
 
 interface StrokeUpdate extends LayerUpdate {
@@ -126,13 +125,23 @@ interface StrokeOpacityUpdate extends LayerUpdate {
 interface AddStrokeUpdate extends LayerUpdate {
   type: 'add-stroke';
   payload: Record<string, never>;
-  layer: CartoKitLayer;
+  layer:
+    | CartoKitPointLayer
+    | CartoKitProportionalSymbolLayer
+    | CartoKitDotDensityLayer
+    | CartoKitFillLayer
+    | CartoKitChoroplethLayer;
 }
 
 interface RemoveStrokeUpdate extends LayerUpdate {
   type: 'remove-stroke';
   payload: Record<string, never>;
-  layer: CartoKitLayer;
+  layer:
+    | CartoKitPointLayer
+    | CartoKitProportionalSymbolLayer
+    | CartoKitDotDensityLayer
+    | CartoKitFillLayer
+    | CartoKitChoroplethLayer;
 }
 
 interface PointSizeUpdate extends LayerUpdate {
@@ -200,9 +209,9 @@ interface TransformationUpdate extends LayerUpdate {
     transformation: Transformation;
   };
   layer:
-    | CartoKitChoroplethLayer
     | CartoKitProportionalSymbolLayer
-    | CartoKitDotDensityLayer;
+    | CartoKitDotDensityLayer
+    | CartoKitChoroplethLayer;
 }
 
 type DispatchLayerUpdateParams =
@@ -234,11 +243,11 @@ type DispatchLayerUpdateParams =
  * @param layer – The CartoKit layer to update.
  * @param payload – The payload for the update.
  */
-export function dispatchLayerUpdate({
+export const dispatchLayerUpdate = ({
   type,
   layer,
   payload
-}: DispatchLayerUpdateParams): void {
+}: DispatchLayerUpdateParams): void => {
   const map = get(mapStore);
 
   switch (type) {
@@ -260,15 +269,11 @@ export function dispatchLayerUpdate({
         // this update. Therefore, accessing that same layer in the store by id
         // guarantees that lyr has an attribute property.
         const lyr = ir.layers[layer.id] as
-          | CartoKitChoroplethLayer
           | CartoKitProportionalSymbolLayer
-          | CartoKitDotDensityLayer;
+          | CartoKitDotDensityLayer
+          | CartoKitChoroplethLayer;
 
         switch (lyr.type) {
-          case 'Choropleth':
-            lyr.style.fill.attribute = payload.attribute;
-            map.setPaintProperty(lyr.id, 'fill-color', deriveColorScale(lyr));
-            break;
           case 'Proportional Symbol':
             lyr.style.size.attribute = payload.attribute;
             map.setPaintProperty(lyr.id, 'circle-radius', deriveSize(lyr));
@@ -293,6 +298,10 @@ export function dispatchLayerUpdate({
             (map.getSource(layer.id) as GeoJSONSource).setData(features);
             break;
           }
+          case 'Choropleth':
+            lyr.style.fill.attribute = payload.attribute;
+            map.setPaintProperty(lyr.id, 'fill-color', deriveColorScale(lyr));
+            break;
         }
 
         return ir;
@@ -303,21 +312,21 @@ export function dispatchLayerUpdate({
       ir.update((ir) => {
         const lyr = ir.layers[layer.id] as
           | CartoKitPointLayer
-          | CartoKitFillLayer
           | CartoKitProportionalSymbolLayer
-          | CartoKitDotDensityLayer;
+          | CartoKitDotDensityLayer
+          | CartoKitFillLayer;
 
         if (lyr.style.fill) {
           lyr.style.fill.color = payload.color;
 
           switch (lyr.type) {
-            case 'Fill':
-              map.setPaintProperty(layer.id, 'fill-color', payload.color);
-              break;
             case 'Point':
             case 'Proportional Symbol':
             case 'Dot Density':
               map.setPaintProperty(layer.id, 'circle-color', payload.color);
+              break;
+            case 'Fill':
+              map.setPaintProperty(layer.id, 'fill-color', payload.color);
               break;
           }
         }
@@ -328,23 +337,25 @@ export function dispatchLayerUpdate({
     }
     case 'fill-opacity': {
       ir.update((ir) => {
-        const lyr = ir.layers[layer.id] as Exclude<
-          CartoKitLayer,
-          CartoKitLineLayer
-        >;
+        const lyr = ir.layers[layer.id] as
+          | CartoKitPointLayer
+          | CartoKitProportionalSymbolLayer
+          | CartoKitDotDensityLayer
+          | CartoKitFillLayer
+          | CartoKitChoroplethLayer;
 
         if (lyr.style.fill) {
           lyr.style.fill.opacity = payload.opacity;
 
           switch (lyr.type) {
-            case 'Fill':
-            case 'Choropleth':
-              map.setPaintProperty(layer.id, 'fill-opacity', payload.opacity);
-              break;
             case 'Point':
             case 'Proportional Symbol':
             case 'Dot Density':
               map.setPaintProperty(layer.id, 'circle-opacity', payload.opacity);
+              break;
+            case 'Fill':
+            case 'Choropleth':
+              map.setPaintProperty(layer.id, 'fill-opacity', payload.opacity);
               break;
           }
         }
@@ -357,24 +368,24 @@ export function dispatchLayerUpdate({
       ir.update((ir) => {
         const lyr = ir.layers[layer.id] as
           | CartoKitPointLayer
-          | CartoKitFillLayer
           | CartoKitProportionalSymbolLayer
-          | CartoKitDotDensityLayer;
+          | CartoKitDotDensityLayer
+          | CartoKitFillLayer;
         lyr.style.fill = {
           color: DEFAULT_FILL,
           opacity: DEFAULT_OPACITY
         };
 
         switch (lyr.type) {
-          case 'Fill':
-            map.setPaintProperty(layer.id, 'fill-color', DEFAULT_FILL);
-            map.setPaintProperty(layer.id, 'fill-opacity', DEFAULT_OPACITY);
-            break;
           case 'Point':
           case 'Proportional Symbol':
           case 'Dot Density':
             map.setPaintProperty(layer.id, 'circle-color', DEFAULT_FILL);
             map.setPaintProperty(layer.id, 'circle-opacity', DEFAULT_OPACITY);
+            break;
+          case 'Fill':
+            map.setPaintProperty(layer.id, 'fill-color', DEFAULT_FILL);
+            map.setPaintProperty(layer.id, 'fill-opacity', DEFAULT_OPACITY);
             break;
         }
 
@@ -386,21 +397,21 @@ export function dispatchLayerUpdate({
       ir.update((ir) => {
         const lyr = ir.layers[layer.id] as
           | CartoKitPointLayer
-          | CartoKitFillLayer
           | CartoKitProportionalSymbolLayer
-          | CartoKitDotDensityLayer;
+          | CartoKitDotDensityLayer
+          | CartoKitFillLayer;
         lyr.style.fill = undefined;
 
         switch (lyr.type) {
-          case 'Fill':
-            map.setPaintProperty(layer.id, 'fill-color', 'transparent');
-            map.setPaintProperty(layer.id, 'fill-opacity', 0);
-            break;
           case 'Point':
           case 'Proportional Symbol':
           case 'Dot Density':
             map.setPaintProperty(layer.id, 'circle-color', 'transparent');
             map.setPaintProperty(layer.id, 'circle-opacity', 0);
+            break;
+          case 'Fill':
+            map.setPaintProperty(layer.id, 'fill-color', 'transparent');
+            map.setPaintProperty(layer.id, 'fill-opacity', 0);
             break;
         }
 
@@ -415,23 +426,23 @@ export function dispatchLayerUpdate({
           lyr.style.stroke.color = payload.color;
 
           switch (lyr.type) {
-            case 'Fill':
-            case 'Choropleth':
-              map.setPaintProperty(
-                `${layer.id}-stroke`,
-                'line-color',
-                payload.color
-              );
-              break;
-            case 'Line':
-              map.setPaintProperty(layer.id, 'line-color', payload.color);
-              break;
             case 'Point':
             case 'Proportional Symbol':
             case 'Dot Density':
               map.setPaintProperty(
                 layer.id,
                 'circle-stroke-color',
+                payload.color
+              );
+              break;
+            case 'Line':
+              map.setPaintProperty(layer.id, 'line-color', payload.color);
+              break;
+            case 'Fill':
+            case 'Choropleth':
+              map.setPaintProperty(
+                `${layer.id}-stroke`,
+                'line-color',
                 payload.color
               );
               break;
@@ -450,23 +461,23 @@ export function dispatchLayerUpdate({
           lyr.style.stroke.width = payload.strokeWidth;
 
           switch (lyr.type) {
-            case 'Fill':
-            case 'Choropleth':
-              map.setPaintProperty(
-                `${layer.id}-stroke`,
-                'line-width',
-                payload.strokeWidth
-              );
-              break;
-            case 'Line':
-              map.setPaintProperty(layer.id, 'line-width', payload.strokeWidth);
-              break;
             case 'Point':
             case 'Proportional Symbol':
             case 'Dot Density':
               map.setPaintProperty(
                 layer.id,
                 'circle-stroke-width',
+                payload.strokeWidth
+              );
+              break;
+            case 'Line':
+              map.setPaintProperty(layer.id, 'line-width', payload.strokeWidth);
+              break;
+            case 'Fill':
+            case 'Choropleth':
+              map.setPaintProperty(
+                `${layer.id}-stroke`,
+                'line-width',
                 payload.strokeWidth
               );
               break;
@@ -485,23 +496,23 @@ export function dispatchLayerUpdate({
           lyr.style.stroke.opacity = payload.opacity;
 
           switch (lyr.type) {
-            case 'Fill':
-            case 'Choropleth':
-              map.setPaintProperty(
-                `${layer.id}-stroke`,
-                'line-opacity',
-                payload.opacity
-              );
-              break;
-            case 'Line':
-              map.setPaintProperty(layer.id, 'line-opacity', payload.opacity);
-              break;
             case 'Point':
             case 'Proportional Symbol':
             case 'Dot Density':
               map.setPaintProperty(
                 layer.id,
                 'circle-stroke-opacity',
+                payload.opacity
+              );
+              break;
+            case 'Line':
+              map.setPaintProperty(layer.id, 'line-opacity', payload.opacity);
+              break;
+            case 'Fill':
+            case 'Choropleth':
+              map.setPaintProperty(
+                `${layer.id}-stroke`,
+                'line-opacity',
                 payload.opacity
               );
               break;
@@ -514,7 +525,12 @@ export function dispatchLayerUpdate({
     }
     case 'add-stroke': {
       ir.update((ir) => {
-        const lyr = ir.layers[layer.id];
+        const lyr = ir.layers[layer.id] as
+          | CartoKitPointLayer
+          | CartoKitProportionalSymbolLayer
+          | CartoKitDotDensityLayer
+          | CartoKitFillLayer
+          | CartoKitChoroplethLayer;
         // Create a default stroke.
         lyr.style.stroke = {
           color: DEFAULT_STROKE,
@@ -523,26 +539,6 @@ export function dispatchLayerUpdate({
         };
 
         switch (lyr.type) {
-          case 'Fill':
-          case 'Choropleth':
-            map.setPaintProperty(
-              `${layer.id}-stroke`,
-              'line-color',
-              DEFAULT_STROKE
-            );
-            map.setPaintProperty(
-              `${layer.id}-stroke`,
-              'line-width',
-              DEFAULT_STROKE_WIDTH
-            );
-            map.setPaintProperty(
-              `${layer.id}-stroke`,
-              'line-opacity',
-              DEFAULT_STROKE_OPACITY
-            );
-            break;
-          case 'Line':
-            break;
           case 'Point':
           case 'Proportional Symbol':
           case 'Dot Density':
@@ -562,6 +558,24 @@ export function dispatchLayerUpdate({
               DEFAULT_STROKE_OPACITY
             );
             break;
+          case 'Fill':
+          case 'Choropleth':
+            map.setPaintProperty(
+              `${layer.id}-stroke`,
+              'line-color',
+              DEFAULT_STROKE
+            );
+            map.setPaintProperty(
+              `${layer.id}-stroke`,
+              'line-width',
+              DEFAULT_STROKE_WIDTH
+            );
+            map.setPaintProperty(
+              `${layer.id}-stroke`,
+              'line-opacity',
+              DEFAULT_STROKE_OPACITY
+            );
+            break;
         }
 
         return ir;
@@ -570,20 +584,15 @@ export function dispatchLayerUpdate({
     }
     case 'remove-stroke': {
       ir.update((ir) => {
-        const lyr = ir.layers[layer.id];
+        const lyr = ir.layers[layer.id] as
+          | CartoKitPointLayer
+          | CartoKitProportionalSymbolLayer
+          | CartoKitDotDensityLayer
+          | CartoKitFillLayer
+          | CartoKitChoroplethLayer;
         lyr.style.stroke = undefined;
 
         switch (lyr.type) {
-          case 'Fill':
-          case 'Choropleth':
-            map.setPaintProperty(
-              `${layer.id}-stroke`,
-              'line-color',
-              'transparent'
-            );
-            map.setPaintProperty(`${layer.id}-stroke`, 'line-width', 0);
-            map.setPaintProperty(`${layer.id}-stroke`, 'line-opacity', 0);
-            break;
           case 'Point':
           case 'Proportional Symbol':
           case 'Dot Density':
@@ -595,7 +604,15 @@ export function dispatchLayerUpdate({
             map.setPaintProperty(layer.id, 'circle-stroke-width', 0);
             map.setPaintProperty(layer.id, 'circle-stroke-opacity', 0);
             break;
-          default:
+          case 'Fill':
+          case 'Choropleth':
+            map.setPaintProperty(
+              `${layer.id}-stroke`,
+              'line-color',
+              'transparent'
+            );
+            map.setPaintProperty(`${layer.id}-stroke`, 'line-width', 0);
+            map.setPaintProperty(`${layer.id}-stroke`, 'line-opacity', 0);
             break;
         }
 
@@ -738,4 +755,4 @@ export function dispatchLayerUpdate({
       });
     }
   }
-}
+};

--- a/src/lib/types/CartoKitLayer.ts
+++ b/src/lib/types/CartoKitLayer.ts
@@ -33,6 +33,46 @@ export interface CartoKitPointLayer extends Layer {
   };
 }
 
+export interface CartoKitProportionalSymbolLayer extends Layer {
+  type: 'Proportional Symbol';
+  style: {
+    size: {
+      attribute: string;
+      min: number;
+      max: number;
+    };
+    fill?: {
+      color: string;
+      opacity: number;
+    };
+    stroke?: {
+      color: string;
+      width: number;
+      opacity: number;
+    };
+  };
+}
+
+export interface CartoKitDotDensityLayer extends Layer {
+  type: 'Dot Density';
+  style: {
+    dots: {
+      attribute: string;
+      size: number;
+      value: number;
+    };
+    fill?: {
+      color: string;
+      opacity: number;
+    };
+    stroke?: {
+      color: string;
+      width: number;
+      opacity: number;
+    };
+  };
+}
+
 export interface CartoKitLineLayer extends Layer {
   type: 'Line';
   style: {
@@ -78,50 +118,10 @@ export interface CartoKitChoroplethLayer extends Layer {
   };
 }
 
-export interface CartoKitProportionalSymbolLayer extends Layer {
-  type: 'Proportional Symbol';
-  style: {
-    size: {
-      attribute: string;
-      min: number;
-      max: number;
-    };
-    fill?: {
-      color: string;
-      opacity: number;
-    };
-    stroke?: {
-      color: string;
-      width: number;
-      opacity: number;
-    };
-  };
-}
-
-export interface CartoKitDotDensityLayer extends Layer {
-  type: 'Dot Density';
-  style: {
-    dots: {
-      attribute: string;
-      size: number;
-      value: number;
-    };
-    fill?: {
-      color: string;
-      opacity: number;
-    };
-    stroke?: {
-      color: string;
-      width: number;
-      opacity: number;
-    };
-  };
-}
-
 export type CartoKitLayer =
   | CartoKitPointLayer
+  | CartoKitProportionalSymbolLayer
+  | CartoKitDotDensityLayer
   | CartoKitLineLayer
   | CartoKitFillLayer
-  | CartoKitChoroplethLayer
-  | CartoKitProportionalSymbolLayer
-  | CartoKitDotDensityLayer;
+  | CartoKitChoroplethLayer;

--- a/src/lib/types/CartoKitLayer.ts
+++ b/src/lib/types/CartoKitLayer.ts
@@ -33,6 +33,17 @@ export interface CartoKitPointLayer extends Layer {
   };
 }
 
+export interface CartoKitLineLayer extends Layer {
+  type: 'Line';
+  style: {
+    stroke: {
+      color: string;
+      width: number;
+      opacity: number;
+    };
+  };
+}
+
 export interface CartoKitFillLayer extends Layer {
   type: 'Fill';
   style: {
@@ -109,6 +120,7 @@ export interface CartoKitDotDensityLayer extends Layer {
 
 export type CartoKitLayer =
   | CartoKitPointLayer
+  | CartoKitLineLayer
   | CartoKitFillLayer
   | CartoKitChoroplethLayer
   | CartoKitProportionalSymbolLayer

--- a/src/lib/types/map-types.ts
+++ b/src/lib/types/map-types.ts
@@ -13,8 +13,8 @@ export type MapType = (typeof MAP_TYPES)[number];
 export const GEOMETRY_TO_MAP_TYPES: Record<Geometry['type'], MapType[]> = {
   Point: ['Point', 'Proportional Symbol'],
   MultiPoint: ['Point', 'Proportional Symbol'],
-  LineString: ['Line'],
-  MultiLineString: ['Line'],
+  LineString: ['Line', 'Point', 'Proportional Symbol'],
+  MultiLineString: ['Line', 'Point', 'Proportional Symbol'],
   Polygon: [
     'Fill',
     'Choropleth',

--- a/src/lib/types/map-types.ts
+++ b/src/lib/types/map-types.ts
@@ -2,6 +2,7 @@ import type { Geometry } from 'geojson';
 
 export const MAP_TYPES = [
   'Point',
+  'Line',
   'Fill',
   'Choropleth',
   'Proportional Symbol',
@@ -12,8 +13,8 @@ export type MapType = (typeof MAP_TYPES)[number];
 export const GEOMETRY_TO_MAP_TYPES: Record<Geometry['type'], MapType[]> = {
   Point: ['Point', 'Proportional Symbol'],
   MultiPoint: ['Point', 'Proportional Symbol'],
-  LineString: [],
-  MultiLineString: [],
+  LineString: ['Line'],
+  MultiLineString: ['Line'],
   Polygon: [
     'Fill',
     'Choropleth',

--- a/src/lib/utils/layer.ts
+++ b/src/lib/utils/layer.ts
@@ -7,7 +7,7 @@ import type { CartoKitLayer } from '$lib/types/CartoKitLayer';
  *
  * @returns – an array of instrumented layer ids.
  */
-export function getInstrumentedLayerIds(layer: CartoKitLayer): string[] {
+export const getInstrumentedLayerIds = (layer: CartoKitLayer): string[] => {
   switch (layer.type) {
     case 'Point':
     case 'Proportional Symbol':
@@ -23,4 +23,4 @@ export function getInstrumentedLayerIds(layer: CartoKitLayer): string[] {
     case 'Choropleth':
       return [`${layer.id}-stroke`, `${layer.id}-hover`, `${layer.id}-select`];
   }
-}
+};

--- a/src/lib/utils/layer.ts
+++ b/src/lib/utils/layer.ts
@@ -7,13 +7,11 @@ import type { CartoKitLayer } from '$lib/types/CartoKitLayer';
  *
  * @returns – an array of instrumented layer ids.
  */
-export function getInstrumetedLayerIds(layer: CartoKitLayer): string[] {
+export function getInstrumentedLayerIds(layer: CartoKitLayer): string[] {
   switch (layer.type) {
-    case 'Fill':
-    case 'Choropleth':
-      return [`${layer.id}-stroke`, `${layer.id}-hover`, `${layer.id}-select`];
     case 'Point':
     case 'Proportional Symbol':
+    case 'Line':
       return [`${layer.id}-hover`, `${layer.id}-select`];
     case 'Dot Density':
       return [
@@ -21,5 +19,8 @@ export function getInstrumetedLayerIds(layer: CartoKitLayer): string[] {
         `${layer.id}-outlines-hover`,
         `${layer.id}-outlines-select`
       ];
+    case 'Fill':
+    case 'Choropleth':
+      return [`${layer.id}-stroke`, `${layer.id}-hover`, `${layer.id}-select`];
   }
 }

--- a/src/lib/utils/maplibre.ts
+++ b/src/lib/utils/maplibre.ts
@@ -1,7 +1,7 @@
 import type { LayerSpecification, Map, SourceSpecification } from 'maplibre-gl';
 
 import type { CartoKitIR } from '$lib/stores/ir';
-import { getInstrumetedLayerIds } from '$lib/utils/layer';
+import { getInstrumentedLayerIds } from '$lib/utils/layer';
 
 /**
  * Switch the basemap of the map while preserving all currently renderedlayers
@@ -23,7 +23,7 @@ export async function switchBasemapWithPreservedLayers(
   const lyrs = Object.values(ir.layers).reduce<LayerSpecification[]>(
     (acc, layer) => {
       // Get the ids of all layers in the IR in addition to their instrumented layers.
-      const ids = [layer.id, ...getInstrumetedLayerIds(layer)];
+      const ids = [layer.id, ...getInstrumentedLayerIds(layer)];
 
       // Return the LayerSpecifications of the layers possessing one of the above ids.
       return [

--- a/src/lib/utils/transformation.ts
+++ b/src/lib/utils/transformation.ts
@@ -1,10 +1,10 @@
 import type { Transformation } from '$lib/types/transformation';
 
-export function transformPolygonsToCentroids(): Transformation {
+export function transformGeometryToCentroids(): Transformation {
   return {
-    name: 'transformPolygonsToCentroids',
+    name: 'transformGeometryToCentroids',
     definition: `
-    function transformPolygonsToCentroids(geoJSON) {
+    function transformGeometryToCentroids(geoJSON) {
       const centroids = geoJSON.features.map((feature) => {
         return turf.feature(turf.centroid(feature).geometry, feature.properties);
       });

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,11 +7,12 @@
   import AddLayer from '$lib/components/layers/AddLayer.svelte';
   import LayerPanel from '$lib/components/layers/LayerPanel.svelte';
   import MapTypeSelect from '$lib/components/map-types/MapTypeSelect.svelte';
-  import PointPropertiesPanel from '$lib/components/properties/PointPropertiesPanel.svelte';
-  import FillPropertiesPanel from '$lib/components/properties/FillPropertiesPanel.svelte';
   import ChoroplethPropertiesPanel from '$lib/components/properties/ChoroplethPropertiesPanel.svelte';
-  import ProportionalSymbolPropertiesPanel from '$lib/components/properties/ProportionalSymbolPropertiesPanel.svelte';
   import DotDensityPropertiesPanel from '$lib/components/properties/DotDensityPropertiesPanel.svelte';
+  import FillPropertiesPanel from '$lib/components/properties/FillPropertiesPanel.svelte';
+  import LinePropertiesPanel from '$lib/components/properties/LinePropertiesPanel.svelte';
+  import PointPropertiesPanel from '$lib/components/properties/PointPropertiesPanel.svelte';
+  import ProportionalSymbolPropertiesPanel from '$lib/components/properties/ProportionalSymbolPropertiesPanel.svelte';
   import Menu from '$lib/components/shared/Menu.svelte';
   import MenuItem from '$lib/components/shared/MenuItem.svelte';
   import MenuTitle from '$lib/components/shared/MenuTitle.svelte';
@@ -89,6 +90,8 @@
           </MenuItem>
           {#if $selectedLayer.type === 'Point'}
             <PointPropertiesPanel layer={$selectedLayer} />
+          {:else if $selectedLayer.type === 'Line'}
+            <LinePropertiesPanel layer={$selectedLayer} />
           {:else if $selectedLayer.type === 'Fill'}
             <FillPropertiesPanel layer={$selectedLayer} />
           {:else if $selectedLayer.type === 'Choropleth'}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,12 +7,12 @@
   import AddLayer from '$lib/components/layers/AddLayer.svelte';
   import LayerPanel from '$lib/components/layers/LayerPanel.svelte';
   import MapTypeSelect from '$lib/components/map-types/MapTypeSelect.svelte';
-  import ChoroplethPropertiesPanel from '$lib/components/properties/ChoroplethPropertiesPanel.svelte';
-  import DotDensityPropertiesPanel from '$lib/components/properties/DotDensityPropertiesPanel.svelte';
-  import FillPropertiesPanel from '$lib/components/properties/FillPropertiesPanel.svelte';
-  import LinePropertiesPanel from '$lib/components/properties/LinePropertiesPanel.svelte';
   import PointPropertiesPanel from '$lib/components/properties/PointPropertiesPanel.svelte';
   import ProportionalSymbolPropertiesPanel from '$lib/components/properties/ProportionalSymbolPropertiesPanel.svelte';
+  import DotDensityPropertiesPanel from '$lib/components/properties/DotDensityPropertiesPanel.svelte';
+  import LinePropertiesPanel from '$lib/components/properties/LinePropertiesPanel.svelte';
+  import FillPropertiesPanel from '$lib/components/properties/FillPropertiesPanel.svelte';
+  import ChoroplethPropertiesPanel from '$lib/components/properties/ChoroplethPropertiesPanel.svelte';
   import Menu from '$lib/components/shared/Menu.svelte';
   import MenuItem from '$lib/components/shared/MenuItem.svelte';
   import MenuTitle from '$lib/components/shared/MenuTitle.svelte';
@@ -90,16 +90,16 @@
           </MenuItem>
           {#if $selectedLayer.type === 'Point'}
             <PointPropertiesPanel layer={$selectedLayer} />
+          {:else if $selectedLayer.type === 'Proportional Symbol'}
+            <ProportionalSymbolPropertiesPanel layer={$selectedLayer} />
+          {:else if $selectedLayer.type === 'Dot Density'}
+            <DotDensityPropertiesPanel layer={$selectedLayer} />
           {:else if $selectedLayer.type === 'Line'}
             <LinePropertiesPanel layer={$selectedLayer} />
           {:else if $selectedLayer.type === 'Fill'}
             <FillPropertiesPanel layer={$selectedLayer} />
           {:else if $selectedLayer.type === 'Choropleth'}
             <ChoroplethPropertiesPanel layer={$selectedLayer} />
-          {:else if $selectedLayer.type === 'Proportional Symbol'}
-            <ProportionalSymbolPropertiesPanel layer={$selectedLayer} />
-          {:else if $selectedLayer.type === 'Dot Density'}
-            <DotDensityPropertiesPanel layer={$selectedLayer} />
           {/if}
         </Menu>
       {/if}


### PR DESCRIPTION
This PR adds support for the final of the Big 3 geometry types for vector geospatial data—(`Multi-`)`LineString`! For example, we can now render 155,000 rivers in south and east Asia!

https://github.com/parkerziegler/cartokit/assets/19421190/52fa3b3f-4a93-45f8-bb8d-95a70794f58b

The implementation is quite straightforward following the structure of #72. The major updates include:

- Addition of instrumentation code for line hover and line selection
- Addition of map type transitions from `Line` to `Point` and `Proportional Symbol`
- Code generation of `Line` layers
- Generalization of the `transformPolygonsToCentroids` to `transformGeometryToCentroids`

Otherwise, 