### PR TITLE
feat: Add support for downloading data.

### DIFF
--- a/src/lib/components/icons/DownloadIcon.svelte
+++ b/src/lib/components/icons/DownloadIcon.svelte
@@ -1,0 +1,26 @@
+<svg
+  width="16"
+  height="16"
+  viewBox="0 0 24 24"
+  xmlns="http://www.w3.org/2000/svg"
+  stroke="currentColor"
+>
+  <path
+    d="M21 15V19C21 19.5304 20.7893 20.0391 20.4142 20.4142C20.0391 20.7893 19.5304 21 19 21H5C4.46957 21 3.96086 20.7893 3.58579 20.4142C3.21071 20.0391 3 19.5304 3 19V15"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M7 10L12 15L17 10"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M12 15V3"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+</svg>

--- a/src/lib/components/legends/FillLegend.svelte
+++ b/src/lib/components/legends/FillLegend.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { CartoKitFillLayer } from '$lib/types/CartoKitLayer';
+  import { pluralize } from '$lib/utils/format';
   import { getLayerGeometryType } from '$lib/utils/geojson';
 
   export let layer: CartoKitFillLayer;
@@ -22,6 +23,6 @@
   </svg>
   <span
     >{layer.data.geoJSON.features.length}
-    {geometryType + (geometryType.length !== 1 ? 's' : '')}</span
+    {pluralize(layer.data.geoJSON.features.length, geometryType)}</span
   >
 </div>

--- a/src/lib/components/legends/FillLegend.svelte
+++ b/src/lib/components/legends/FillLegend.svelte
@@ -23,6 +23,6 @@
   </svg>
   <span
     >{layer.data.geoJSON.features.length}
-    {pluralize(layer.data.geoJSON.features.length, geometryType)}</span
+    {pluralize(geometryType, layer.data.geoJSON.features.length)}</span
   >
 </div>

--- a/src/lib/components/legends/LineLegend.svelte
+++ b/src/lib/components/legends/LineLegend.svelte
@@ -25,6 +25,6 @@
   </svg>
   <span
     >{layer.data.geoJSON.features.length}
-    {pluralize(layer.data.geoJSON.features.length, geometryType)}</span
+    {pluralize(geometryType, layer.data.geoJSON.features.length)}</span
   >
 </div>

--- a/src/lib/components/legends/LineLegend.svelte
+++ b/src/lib/components/legends/LineLegend.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { CartoKitLineLayer } from '$lib/types/CartoKitLayer';
+  import { pluralize } from '$lib/utils/format';
   import { getLayerGeometryType } from '$lib/utils/geojson';
 
   export let layer: CartoKitLineLayer;
@@ -24,6 +25,6 @@
   </svg>
   <span
     >{layer.data.geoJSON.features.length}
-    {geometryType + (geometryType.length !== 1 ? 's' : '')}</span
+    {pluralize(layer.data.geoJSON.features.length, geometryType)}</span
   >
 </div>

--- a/src/lib/components/legends/PointLegend.svelte
+++ b/src/lib/components/legends/PointLegend.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { CartoKitPointLayer } from '$lib/types/CartoKitLayer';
+  import { pluralize } from '$lib/utils/format';
   import { getLayerGeometryType } from '$lib/utils/geojson';
 
   export let layer: CartoKitPointLayer;
@@ -26,6 +27,6 @@
   </svg>
   <span
     >{layer.data.geoJSON.features.length}
-    {geometryType + (geometryType.length !== 1 ? 's' : '')}</span
+    {pluralize(layer.data.geoJSON.features.length, geometryType)}</span
   >
 </div>

--- a/src/lib/components/legends/PointLegend.svelte
+++ b/src/lib/components/legends/PointLegend.svelte
@@ -27,6 +27,6 @@
   </svg>
   <span
     >{layer.data.geoJSON.features.length}
-    {pluralize(layer.data.geoJSON.features.length, geometryType)}</span
+    {pluralize(geometryType, layer.data.geoJSON.features.length)}</span
   >
 </div>

--- a/src/lib/components/properties/DownloadData.svelte
+++ b/src/lib/components/properties/DownloadData.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import kebabCase from 'lodash.kebabcase';
+
+  import DownloadIcon from '$lib/components/icons/DownloadIcon.svelte';
+  import type { CartoKitLayer } from '$lib/types/CartoKitLayer';
+
+  export let layer: CartoKitLayer;
+
+  function onClick() {
+    const blob = new Blob([JSON.stringify(layer.data.geoJSON, null, 2)], {
+      type: 'application/json'
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${kebabCase(layer.displayName)}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+</script>
+
+<button on:click={onClick}>
+  <DownloadIcon />
+</button>

--- a/src/lib/components/properties/PropertiesMenu.svelte
+++ b/src/lib/components/properties/PropertiesMenu.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+  import cs from 'classnames';
+  import maplibregl from 'maplibre-gl';
+
+  import CloseIcon from '$lib/components/icons/CloseIcon.svelte';
+  import MapTypeSelect from '$lib/components/map-types/MapTypeSelect.svelte';
+  import ChoroplethPropertiesPanel from '$lib/components/properties/ChoroplethPropertiesPanel.svelte';
+  import DotDensityPropertiesPanel from '$lib/components/properties/DotDensityPropertiesPanel.svelte';
+  import DownloadData from '$lib/components/properties/DownloadData.svelte';
+  import FillPropertiesPanel from '$lib/components/properties/FillPropertiesPanel.svelte';
+  import LinePropertiesPanel from '$lib/components/properties/LinePropertiesPanel.svelte';
+  import PointPropertiesPanel from '$lib/components/properties/PointPropertiesPanel.svelte';
+  import ProportionalSymbolPropertiesPanel from '$lib/components/properties/ProportionalSymbolPropertiesPanel.svelte';
+  import ViewData from '$lib/components/properties/ViewData.svelte';
+  import Menu from '$lib/components/shared/Menu.svelte';
+  import MenuItem from '$lib/components/shared/MenuItem.svelte';
+  import MenuTitle from '$lib/components/shared/MenuTitle.svelte';
+  import { layout } from '$lib/stores/layout';
+  import { selectedFeature } from '$lib/stores/selected-feature';
+  import type { CartoKitLayer } from '$lib/types/CartoKitLayer';
+
+  export let map: maplibregl.Map;
+  export let layer: CartoKitLayer;
+
+  function onPropertiesMenuClose() {
+    if ($selectedFeature) {
+      map.removeFeatureState(
+        { source: $selectedFeature.layer.id, id: $selectedFeature.id },
+        'selected'
+      );
+
+      selectedFeature.set(null);
+    }
+
+    if ($layout.dataVisible) {
+      layout.update((layout) => {
+        layout.dataVisible = false;
+
+        return layout;
+      });
+    }
+  }
+</script>
+
+<Menu
+  id="properties"
+  class={cs('properties absolute right-4 top-4 z-10 max-w-sm overflow-auto', {
+    'properties--y-compact': $layout.dataVisible,
+    'properties--x-compact': $layout.editorVisible
+  })}
+>
+  <MenuTitle class="mr-4"
+    >{layer.displayName}
+    <button on:click={onPropertiesMenuClose} slot="action">
+      <CloseIcon />
+    </button>
+    <div class="stack-h stack-h-xs" slot="subtitle">
+      <ViewData />
+      <DownloadData {layer} />
+    </div>
+  </MenuTitle>
+  <MenuItem title="Map Type">
+    <MapTypeSelect {layer} />
+  </MenuItem>
+  {#if layer.type === 'Point'}
+    <PointPropertiesPanel {layer} />
+  {:else if layer.type === 'Proportional Symbol'}
+    <ProportionalSymbolPropertiesPanel {layer} />
+  {:else if layer.type === 'Dot Density'}
+    <DotDensityPropertiesPanel {layer} />
+  {:else if layer.type === 'Line'}
+    <LinePropertiesPanel {layer} />
+  {:else if layer.type === 'Fill'}
+    <FillPropertiesPanel {layer} />
+  {:else if layer.type === 'Choropleth'}
+    <ChoroplethPropertiesPanel {layer} />
+  {/if}
+</Menu>

--- a/src/lib/components/properties/ViewData.svelte
+++ b/src/lib/components/properties/ViewData.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import TableIcon from '$lib/components/icons/TableIcon.svelte';
+  import { layout } from '$lib/stores/layout';
+
+  function onViewDataClick() {
+    layout.update((layout) => {
+      layout.dataVisible = !layout.dataVisible;
+
+      return layout;
+    });
+  }
+</script>
+
+<button on:click={onViewDataClick}>
+  <TableIcon />
+</button>

--- a/src/lib/components/shared/DataTable.svelte
+++ b/src/lib/components/shared/DataTable.svelte
@@ -105,7 +105,7 @@
       {tableName}
     </span>
     <div class="stack-h stack-h-sm">
-      <span>{N} {pluralize(N, 'Feature')}</span>
+      <span>{N} {pluralize('Feature', N)}</span>
       <button on:click={onClose}>
         <CloseIcon />
       </button>

--- a/src/lib/components/shared/DataTable.svelte
+++ b/src/lib/components/shared/DataTable.svelte
@@ -10,6 +10,7 @@
   /* eslint-enable import/no-duplicates */
 
   import CloseIcon from '$lib/components/icons/CloseIcon.svelte';
+  import { pluralize } from '$lib/utils/format';
 
   const ROW_HEIGHT = 33;
   const rows = 7;
@@ -104,7 +105,7 @@
       {tableName}
     </span>
     <div class="stack-h stack-h-sm">
-      <span>{N} Features</span>
+      <span>{N} {pluralize(N, 'Feature')}</span>
       <button on:click={onClose}>
         <CloseIcon />
       </button>

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -6,6 +6,6 @@
  * @param suffix – The pluralization suffix.
  * @returns – The pluralized noun, if necessary.
  */
-export function pluralize(n: number, noun: string, suffix = 's'): string {
+export function pluralize(noun: string, n: number, suffix = 's'): string {
   return n === 1 ? noun : `${noun}${suffix}`;
 }

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -1,0 +1,11 @@
+/**
+ * Pluralize a noun based on a number.
+ *
+ * @param n – The number to base the pluralization on.
+ * @param noun – The noun to pluralize.
+ * @param suffix – The pluralization suffix.
+ * @returns – The pluralized noun, if necessary.
+ */
+export function pluralize(n: number, noun: string, suffix = 's'): string {
+  return n === 1 ? noun : `${noun}${suffix}`;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,27 +7,17 @@
 
   import BasemapPicker from '$lib/components/basemap/BasemapPicker.svelte';
   import Editor from '$lib/components/editor/Editor.svelte';
-  import CloseIcon from '$lib/components/icons/CloseIcon.svelte';
-  import TableIcon from '$lib/components/icons/TableIcon.svelte';
   import AddLayer from '$lib/components/layers/AddLayer.svelte';
   import LayerPanel from '$lib/components/layers/LayerPanel.svelte';
-  import MapTypeSelect from '$lib/components/map-types/MapTypeSelect.svelte';
-  import ChoroplethPropertiesPanel from '$lib/components/properties/ChoroplethPropertiesPanel.svelte';
-  import DotDensityPropertiesPanel from '$lib/components/properties/DotDensityPropertiesPanel.svelte';
-  import FillPropertiesPanel from '$lib/components/properties/FillPropertiesPanel.svelte';
-  import LinePropertiesPanel from '$lib/components/properties/LinePropertiesPanel.svelte';
-  import PointPropertiesPanel from '$lib/components/properties/PointPropertiesPanel.svelte';
-  import ProportionalSymbolPropertiesPanel from '$lib/components/properties/ProportionalSymbolPropertiesPanel.svelte';
+  import PropertiesMenu from '$lib/components/properties/PropertiesMenu.svelte';
   import Button from '$lib/components/shared/Button.svelte';
   import DataTable from '$lib/components/shared/DataTable.svelte';
   import Menu from '$lib/components/shared/Menu.svelte';
-  import MenuItem from '$lib/components/shared/MenuItem.svelte';
   import MenuTitle from '$lib/components/shared/MenuTitle.svelte';
   import { onFeatureLeave } from '$lib/interaction/select';
   import { ir } from '$lib/stores/ir';
   import { layout } from '$lib/stores/layout';
   import { map as mapStore } from '$lib/stores/map';
-  import { selectedFeature } from '$lib/stores/selected-feature';
   import { selectedLayer } from '$lib/stores/selected-layer';
 
   export let data: PageData;
@@ -83,48 +73,21 @@
     };
   });
 
-  const toggleEditorVisibility = () => {
+  function toggleEditorVisibility() {
     layout.update((layout) => {
       layout.editorVisible = !layout.editorVisible;
 
       return layout;
     });
-  };
+  }
 
-  const onViewDataClick = () => {
-    layout.update((layout) => {
-      layout.dataVisible = !layout.dataVisible;
-
-      return layout;
-    });
-  };
-
-  const onViewDataClose = () => {
+  function onViewDataClose() {
     layout.update((layout) => {
       layout.dataVisible = false;
 
       return layout;
     });
-  };
-
-  const onPropertiesMenuClose = () => {
-    if ($selectedFeature) {
-      map.removeFeatureState(
-        { source: $selectedFeature.layer.id, id: $selectedFeature.id },
-        'selected'
-      );
-
-      selectedFeature.set(null);
-    }
-
-    if ($layout.dataVisible) {
-      layout.update((layout) => {
-        layout.dataVisible = false;
-
-        return layout;
-      });
-    }
-  };
+  }
 </script>
 
 <main class="absolute inset-0">
@@ -142,44 +105,7 @@
       <LayerPanel />
     </Menu>
     {#if $selectedLayer}
-      <Menu
-        id="properties"
-        class={cs(
-          'properties absolute right-4 top-4 z-10 max-w-sm overflow-auto',
-          {
-            'properties--y-compact': $layout.dataVisible,
-            'properties--x-compact': $layout.editorVisible
-          }
-        )}
-      >
-        <MenuTitle class="mr-4"
-          >{$selectedLayer.displayName}
-          <button on:click={onPropertiesMenuClose} slot="action">
-            <CloseIcon />
-          </button>
-          <div class="stack-h stack-h-xs" slot="subtitle">
-            <button on:click={onViewDataClick}>
-              <TableIcon />
-            </button>
-          </div>
-        </MenuTitle>
-        <MenuItem title="Map Type">
-          <MapTypeSelect layer={$selectedLayer} />
-        </MenuItem>
-        {#if $selectedLayer.type === 'Point'}
-          <PointPropertiesPanel layer={$selectedLayer} />
-        {:else if $selectedLayer.type === 'Proportional Symbol'}
-          <ProportionalSymbolPropertiesPanel layer={$selectedLayer} />
-        {:else if $selectedLayer.type === 'Dot Density'}
-          <DotDensityPropertiesPanel layer={$selectedLayer} />
-        {:else if $selectedLayer.type === 'Line'}
-          <LinePropertiesPanel layer={$selectedLayer} />
-        {:else if $selectedLayer.type === 'Fill'}
-          <FillPropertiesPanel layer={$selectedLayer} />
-        {:else if $selectedLayer.type === 'Choropleth'}
-          <ChoroplethPropertiesPanel layer={$selectedLayer} />
-        {/if}
-      </Menu>
+      <PropertiesMenu {map} layer={$selectedLayer} />
     {/if}
     <BasemapPicker />
     <Button


### PR DESCRIPTION
This PR adds support for downloading GeoJSON data from `cartokit`. While `cartokit`-generated programs always operate on the originally uploaded data to preserve provenance, it's reasonable that users may want to export transformed data for other reasons. Now within the Properties Menu, users have access to a download button to grab their latest data as GeoJSON.

https://github.com/parkerziegler/cartokit/assets/19421190/e2b7042d-92e9-423e-ae51-53ffd4a05b1e

In addition, we snuck a few bugfixes and QOL improvements into this PR.

- Our legends and data table headers incorrectly pluralized certain nouns.
- We pulled out the Properties Menu into its own component rather than keeping it in `+page.svelte`.