### PR TITLE
test: Resolve e2e test flake by removing reliance on networkidle.

### DIFF
--- a/tests/workflows/workflow-1.spec.ts
+++ b/tests/workflows/workflow-1.spec.ts
@@ -17,12 +17,26 @@ const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
  * iles (i.e., 10%-90% coverage).
  */
 test('workflow-1', async ({ page }) => {
+  // Mark workflow tests as slow.
+  test.slow();
+
   // Navigate to cartokit, running on a local development server.
   await page.goto('/');
 
-  // Wait for MapLibre to request tiles from the tile server and instantiate the
-  // map instance.
-  await page.waitForLoadState('networkidle');
+  // Wait for the Open Editor button and Add Layer button to become enabled. These
+  // are proxies for the map reaching an idle state.
+  await expect(page.getByTestId('editor-toggle')).toBeEnabled({
+    timeout: 10000
+  });
+  await expect(page.getByTestId('add-layer-button')).toBeEnabled({
+    timeout: 10000
+  });
+
+  // Click the Open Editor button.
+  await page.getByTestId('editor-toggle').click();
+
+  // Ensure the Editor Panel is visible.
+  await expect(page.getByTestId('program-editor')).toBeVisible();
 
   // Focus the map and trigger a 'wheel' event to zoom out.
   await page.locator('#map').click({
@@ -32,13 +46,6 @@ test('workflow-1', async ({ page }) => {
     }
   });
   await page.mouse.wheel(0, 400);
-
-  // Click the Open Editor button.
-  await expect(page.getByTestId('editor-toggle')).toBeEnabled();
-  await page.getByTestId('editor-toggle').click();
-
-  // Ensure the Editor Panel is visible.
-  await expect(page.getByTestId('program-editor')).toBeVisible();
 
   // Open the Add Layer modal.
   await expect(page.getByTestId('add-layer-button')).toBeEnabled();
@@ -74,7 +81,7 @@ test('workflow-1', async ({ page }) => {
   // load. In theory, we'd like to hook into MapLibre's event system to deter-
   // mine when the map is idle; however, we don't want to attach the map inst-
   // ance to the global window object just for the sake of testing.
-  await page.waitForTimeout(2000);
+  await page.waitForTimeout(5000);
 
   // Click on a page location that will trigger selection of the Penumbra Paths
   // layer.
@@ -165,7 +172,7 @@ test('workflow-1', async ({ page }) => {
   // load. In theory, we'd like to hook into MapLibre's event system to deter-
   // mine when the map is idle; however, we don't want to attach the map inst-
   // ance to the global window object just for the sake of testing.
-  await page.waitForTimeout(2000);
+  await page.waitForTimeout(5000);
 
   // Click on a page location that will trigger selection of the Path of Total-
   // ity layer.

--- a/tests/workflows/workflow-2.spec.ts
+++ b/tests/workflows/workflow-2.spec.ts
@@ -62,16 +62,27 @@ test.afterAll(() => {
  * at that location in geographic space from 1981-2023.
  */
 test('workflow-2', async ({ page }) => {
-  // Mark this test as slow. We're working with a 129MB GeoJSON file, which will
-  // take some time for MapLibre to render, even at high zooms.
+  // Mark workflow tests as slow.
   test.slow();
 
   // Navigate to cartokit, running on a local development server.
   await page.goto('/');
 
-  // Wait for MapLibre to request tiles from the tile server and instantiate the
-  // map instance.
-  await page.waitForLoadState('networkidle');
+  // Wait for the Open Editor button and Add Layer button to become enabled. These
+  // are proxies for the map reaching an idle state.
+  await expect(page.getByTestId('editor-toggle')).toBeEnabled({
+    timeout: 10000
+  });
+  await expect(page.getByTestId('add-layer-button')).toBeEnabled({
+    timeout: 10000
+  });
+
+  // Click the Open Editor button.
+  await expect(page.getByTestId('editor-toggle')).toBeEnabled();
+  await page.getByTestId('editor-toggle').click();
+
+  // Ensure the Editor Panel is visible.
+  await expect(page.getByTestId('program-editor')).toBeVisible();
 
   // Pan and zoom the map to the Bay Area to reduce future rendering time when
   // MapLibre generates tiles on the fly.
@@ -94,13 +105,6 @@ test('workflow-2', async ({ page }) => {
     });
     await page.mouse.wheel(0, -1200);
   }
-
-  // Click the Open Editor button.
-  await expect(page.getByTestId('editor-toggle')).toBeEnabled();
-  await page.getByTestId('editor-toggle').click();
-
-  // Ensure the Editor Panel is visible.
-  await expect(page.getByTestId('program-editor')).toBeVisible();
 
   // Open the Add Layer modal.
   await expect(page.getByTestId('add-layer-button')).toBeEnabled();
@@ -139,7 +143,7 @@ test('workflow-2', async ({ page }) => {
   // load. In theory, we'd like to hook into MapLibre's event system to deter-
   // mine when the map is idle; however, we don't want to attach the map inst-
   // ance to the global window object just for the sake of testing.
-  await page.waitForTimeout(5000);
+  await page.waitForTimeout(20000);
 
   // Click on a page location that will trigger selection of the Spring Leaf
   // Appearance layer.

--- a/tests/workflows/workflow-3.spec.ts
+++ b/tests/workflows/workflow-3.spec.ts
@@ -65,16 +65,26 @@ test.afterAll(() => {
  * location in geographic space from 1980-2024.
  */
 test('workflow-3', async ({ page }) => {
-  // Mark this test as slow. We're working with a 250MB GeoJSON file, which will
-  // take some time for MapLibre to render, even at high zooms.
+  // Mark workflow tests as slow.
   test.slow();
 
   // Navigate to cartokit, running on a local development server.
   await page.goto('/');
 
-  // Wait for MapLibre to request tiles from the tile server and instantiate the
-  // map instance.
-  await page.waitForLoadState('networkidle');
+  // Wait for the Open Editor button and Add Layer button to become enabled. These
+  // are proxies for the map reaching an idle state.
+  await expect(page.getByTestId('editor-toggle')).toBeEnabled({
+    timeout: 10000
+  });
+  await expect(page.getByTestId('add-layer-button')).toBeEnabled({
+    timeout: 10000
+  });
+
+  // Click the Open Editor button.
+  await page.getByTestId('editor-toggle').click();
+
+  // Ensure the Editor Panel is visible.
+  await expect(page.getByTestId('program-editor')).toBeVisible();
 
   // Pan and zoom the map to the Bay Area to reduce future rendering time when
   // MapLibre generates tiles on the fly.
@@ -97,13 +107,6 @@ test('workflow-3', async ({ page }) => {
     });
     await page.mouse.wheel(0, -1200);
   }
-
-  // Click the Open Editor button.
-  await expect(page.getByTestId('editor-toggle')).toBeEnabled();
-  await page.getByTestId('editor-toggle').click();
-
-  // Ensure the Editor Panel is visible.
-  await expect(page.getByTestId('program-editor')).toBeVisible();
 
   // Open the Add Layer modal.
   await expect(page.getByTestId('add-layer-button')).toBeEnabled();
@@ -130,7 +133,7 @@ test('workflow-3', async ({ page }) => {
   // Add the layer.
   await page.getByRole('button', { name: 'Add' }).click();
   await expect(page.getByTestId('add-layer-modal')).not.toBeVisible({
-    timeout: 10000
+    timeout: 30000
   });
 
   // Wait for MapLibre to render the Winter Temperature Change layer.
@@ -139,7 +142,7 @@ test('workflow-3', async ({ page }) => {
   // load. In theory, we'd like to hook into MapLibre's event system to deter-
   // mine when the map is idle; however, we don't want to attach the map inst-
   // ance to the global window object just for the sake of testing.
-  await page.waitForTimeout(10000);
+  await page.waitForTimeout(20000);
 
   // Click on a page location that will trigger selection of the Winter Tempera-
   // ture Change layer.

--- a/tests/workflows/workflow-4.spec.ts
+++ b/tests/workflows/workflow-4.spec.ts
@@ -16,13 +16,24 @@ const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
  * Identification System) transpoder signal disabling events at that location in
  * geographic space.
  */
-test('workflow-4', async ({ page }) => {
+test('workflow-4', async ({ page, browserName }) => {
   // Navigate to cartokit, running on a local development server.
   await page.goto('/');
 
-  // Wait for MapLibre to request tiles from the tile server and instantiate the
-  // map instance.
-  await page.waitForLoadState('networkidle');
+  // Wait for the Open Editor button and Add Layer button to become enabled. These
+  // are proxies for the map reaching an idle state.
+  await expect(page.getByTestId('editor-toggle')).toBeEnabled({
+    timeout: 10000
+  });
+  await expect(page.getByTestId('add-layer-button')).toBeEnabled({
+    timeout: 10000
+  });
+
+  // Click the Open Editor button.
+  await page.getByTestId('editor-toggle').click();
+
+  // Ensure the Editor Panel is visible.
+  await expect(page.getByTestId('program-editor')).toBeVisible();
 
   // Focus the map and trigger a 'wheel' event to zoom out.
   await page.locator('#map').click({
@@ -40,19 +51,12 @@ test('workflow-4', async ({ page }) => {
       y: 360
     }
   });
+
   await page.mouse.down();
-  await page.mouse.move(-100, -600);
+  await page.mouse.move(-50, -400);
   await page.mouse.up();
 
-  // Click the Open Editor button.
-  await expect(page.getByTestId('editor-toggle')).toBeEnabled();
-  await page.getByTestId('editor-toggle').click();
-
-  // Ensure the Editor Panel is visible.
-  await expect(page.getByTestId('program-editor')).toBeVisible();
-
   // Open the Add Layer modal.
-  await expect(page.getByTestId('add-layer-button')).toBeEnabled();
   await page.getByTestId('add-layer-button').click();
   await expect(page.getByTestId('add-layer-modal')).toBeVisible();
 
@@ -88,14 +92,14 @@ test('workflow-4', async ({ page }) => {
   // load. In theory, we'd like to hook into MapLibre's event system to deter-
   // mine when the map is idle; however, we don't want to attach the map inst-
   // ance to the global window object just for the sake of testing.
-  await page.waitForTimeout(2000);
+  await page.waitForTimeout(5000);
 
   // Click on a page location that will trigger selection of the Fishing Boat
   // Transponder Gaps layer.
   await page.locator('#map').click({
     position: {
-      x: 340,
-      y: 500
+      x: 180,
+      y: 300
     }
   });
 

--- a/tests/workflows/workflow-4.spec.ts
+++ b/tests/workflows/workflow-4.spec.ts
@@ -16,7 +16,7 @@ const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
  * Identification System) transpoder signal disabling events at that location in
  * geographic space.
  */
-test('workflow-4', async ({ page, browserName }) => {
+test('workflow-4', async ({ page }) => {
   // Navigate to cartokit, running on a local development server.
   await page.goto('/');
 

--- a/tests/workflows/workflow-5.spec.ts
+++ b/tests/workflows/workflow-5.spec.ts
@@ -17,15 +17,22 @@ const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
  * nental United States from 2012-2022.
  */
 test('workflow-5', async ({ page }) => {
+  // Mark workflow tests as slow.
+  test.slow();
+
   // Navigate to cartokit, running on a local development server.
   await page.goto('/');
 
-  // Wait for MapLibre to request tiles from the tile server and instantiate the
-  // map instance.
-  await page.waitForLoadState('networkidle');
+  // Wait for the Open Editor button and Add Layer button to become enabled. These
+  // are proxies for the map reaching an idle state.
+  await expect(page.getByTestId('editor-toggle')).toBeEnabled({
+    timeout: 10000
+  });
+  await expect(page.getByTestId('add-layer-button')).toBeEnabled({
+    timeout: 10000
+  });
 
   // Click the Open Editor button.
-  await expect(page.getByTestId('editor-toggle')).toBeEnabled();
   await page.getByTestId('editor-toggle').click();
 
   // Ensure the Editor Panel is visible.
@@ -68,7 +75,7 @@ test('workflow-5', async ({ page }) => {
   // load. In theory, we'd like to hook into MapLibre's event system to deter-
   // mine when the map is idle; however, we don't want to attach the map inst-
   // ance to the global window object just for the sake of testing.
-  await page.waitForTimeout(500);
+  await page.waitForTimeout(5000);
 
   // Click on a page location that will trigger selection of the American Crow
   // Range layer.
@@ -137,7 +144,7 @@ test('workflow-5', async ({ page }) => {
   // load. In theory, we'd like to hook into MapLibre's event system to deter-
   // mine when the map is idle; however, we don't want to attach the map inst-
   // ance to the global window object just for the sake of testing.
-  await page.waitForTimeout(2000);
+  await page.waitForTimeout(5000);
 
   // Click on a page location that will trigger selection of the American Crow
   // Population Change layer.

--- a/tests/workflows/workflow-6.spec.ts
+++ b/tests/workflows/workflow-6.spec.ts
@@ -16,15 +16,22 @@ const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
  * https://academic.oup.com/qje/article/137/4/2037/6571943
  */
 test('workflow-6', async ({ page }) => {
+  // Mark workflow tests as slow.
+  test.slow();
+
   // Navigate to cartokit, running on a local development server.
   await page.goto('/');
 
-  // Wait for MapLibre to request tiles from the tile server and instantiate the
-  // map instance.
-  await page.waitForLoadState('networkidle');
+  // Wait for the Open Editor button and Add Layer button to become enabled. These
+  // are proxies for the map reaching an idle state.
+  await expect(page.getByTestId('editor-toggle')).toBeEnabled({
+    timeout: 10000
+  });
+  await expect(page.getByTestId('add-layer-button')).toBeEnabled({
+    timeout: 10000
+  });
 
   // Click the Open Editor button.
-  await expect(page.getByTestId('editor-toggle')).toBeEnabled();
   await page.getByTestId('editor-toggle').click();
 
   // Ensure the Editor Panel is visible.
@@ -67,7 +74,7 @@ test('workflow-6', async ({ page }) => {
   // load. In theory, we'd like to hook into MapLibre's event system to deter-
   // mine when the map is idle; however, we don't want to attach the map inst-
   // ance to the global window object just for the sake of testing.
-  await page.waitForTimeout(2000);
+  await page.waitForTimeout(5000);
 
   // Click on a page location that will trigger selection of the Climate Impact
   // Regions layer.


### PR DESCRIPTION
This PR aims to reduce test flake in our e2e workflows caused by reliance on Playwright's [`waitForLoadState` API](https://playwright.dev/docs/api/class-page#page-wait-for-load-state) using the `networkidle` state. Waiting for this particular state is discouraged in the Playwright docs:

> 'networkidle' - DISCOURAGED wait until there are no network connections for at least 500 ms. Don't use this method for testing, rely on web assertions to assess readiness instead.

and we've found that it's consistently the source of test run failures. Instead, we rely on web first assertions. Specifically, we check that our Add Layer button and Open Editor button are both enabled, which is triggered when the MapLibre map reaches an `idle` state and the `map` store has been created.

In general, this PR also increases our timeouts for checking assertions and allowing MapLibre to complete GeoJSON tiling when new layers are added. Both of these changes are leading to much more consistent tests on local dev, which were previously failing frequently even when passing in CI.