### PR TITLE
fix: Reduce font size and spacing on Properties Panel.

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -14,6 +14,10 @@
     margin-block: 0;
   }
 
+  .stack-2xs > * + * {
+    margin-block-start: 0.25rem;
+  }
+
   .stack-xs > * + * {
     margin-block-start: 0.5rem;
   }

--- a/src/lib/components/color/ColorPalette.svelte
+++ b/src/lib/components/color/ColorPalette.svelte
@@ -9,7 +9,7 @@
   export let layer: CartoKitChoroplethLayer;
 </script>
 
-<div class="stack stack-xs">
+<div class="stack stack-2xs">
   <AttributeSelect {layer} selected={layer.style.fill.attribute} />
   <ColorScaleMethodSelect {layer} />
   <ColorScaleStepsSelect {layer} />

--- a/src/lib/components/color/FillPicker.svelte
+++ b/src/lib/components/color/FillPicker.svelte
@@ -41,7 +41,7 @@
 </script>
 
 {#if layer.style.fill}
-  <div class="color-picker stack stack-xs" transition:slide>
+  <div class="color-picker stack stack-2xs" transition:slide>
     <div class="flex items-center">
       <FieldLabel fieldId="fill-color">Color</FieldLabel>
       <input

--- a/src/lib/components/color/StrokePicker.svelte
+++ b/src/lib/components/color/StrokePicker.svelte
@@ -45,7 +45,7 @@
 </script>
 
 {#if layer.style.stroke}
-  <div class="color-picker stack stack-xs" transition:slide>
+  <div class="color-picker stack stack-2xs" transition:slide>
     <div class="flex items-center">
       <FieldLabel fieldId="stroke-color">Color</FieldLabel>
       <input
@@ -68,7 +68,7 @@
         id="stroke-width-input"
         value={layer.style.stroke.width}
         on:change={onStrokeWidthChange}
-        class="w-12"
+        class="w-10"
       />
     </div>
     <OpacityInput {layer} property="stroke" />

--- a/src/lib/components/dots/DotControls.svelte
+++ b/src/lib/components/dots/DotControls.svelte
@@ -8,7 +8,7 @@
 
   export let layer: CartoKitDotDensityLayer;
 
-  const onDotValueChange = (event: CustomEvent<{ value: number }>) => {
+  function onDotValueChange(event: CustomEvent<{ value: number }>) {
     dispatchLayerUpdate({
       type: 'dot-value',
       layer,
@@ -16,10 +16,10 @@
         value: event.detail.value
       }
     });
-  };
+  }
 </script>
 
-<div class="stack stack-xs">
+<div class="stack stack-2xs">
   <AttributeSelect {layer} selected={layer.style.dots.attribute} />
   <PointSize {layer} />
   <div class="stack-h stack-h-xs items-center">

--- a/src/lib/components/dots/DotControls.svelte
+++ b/src/lib/components/dots/DotControls.svelte
@@ -30,6 +30,7 @@
       max={Infinity}
       value={layer.style.dots.value}
       on:change={onDotValueChange}
+      class="w-10"
     />
   </div>
 </div>

--- a/src/lib/components/layers/FromFile.svelte
+++ b/src/lib/components/layers/FromFile.svelte
@@ -64,7 +64,7 @@
 <form class="stack stack-sm" on:submit={onSubmit}>
   <div class="stack stack-xs">
     <FieldLabel fieldId="from-file-input">File</FieldLabel>
-    <FileInput id="from-file-input" on:change={onFileUpload} />
+    <FileInput id="from-file-input" on:change={onFileUpload} {file} />
   </div>
   <div class="stack stack-xs">
     <FieldLabel fieldId="Display Name">Display Name</FieldLabel>

--- a/src/lib/components/layers/LayerEntry.svelte
+++ b/src/lib/components/layers/LayerEntry.svelte
@@ -57,7 +57,10 @@
           <ChoroplethIcon />
         {/if}
       </span>
-      <span class="ml-2 mr-8 truncate text-sm">{layer.displayName}</span>
+      <span
+        class="ml-2 mr-8 truncate font-sans text-sm font-medium tracking-wider"
+        >{layer.displayName}</span
+      >
     </div>
     {#if layerVisible}
       <button on:click={toggleLayerVisibility}>

--- a/src/lib/components/point/PointSize.svelte
+++ b/src/lib/components/point/PointSize.svelte
@@ -9,7 +9,7 @@
 
   export let layer: CartoKitPointLayer | CartoKitDotDensityLayer;
 
-  const onPointSizeChange = (event: CustomEvent<{ value: number }>): void => {
+  function onPointSizeChange(event: CustomEvent<{ value: number }>): void {
     dispatchLayerUpdate({
       type: 'point-size',
       layer,
@@ -17,7 +17,7 @@
         size: event.detail.value
       }
     });
-  };
+  }
 
   $: ({ size, fieldId, label } =
     layer.type === 'Point'
@@ -37,5 +37,6 @@
     max={Infinity}
     value={size}
     on:change={onPointSizeChange}
+    class="w-10"
   />
 </div>

--- a/src/lib/components/properties/PropertiesMenu.svelte
+++ b/src/lib/components/properties/PropertiesMenu.svelte
@@ -44,7 +44,7 @@
 
 <Menu
   id="properties"
-  class={cs('properties absolute right-4 top-4 z-10 max-w-sm overflow-auto', {
+  class={cs('properties absolute right-4 top-4 z-10 overflow-auto', {
     'properties--y-compact': $layout.dataVisible,
     'properties--x-compact': $layout.editorVisible
   })}

--- a/src/lib/components/shared/FileInput.svelte
+++ b/src/lib/components/shared/FileInput.svelte
@@ -2,10 +2,11 @@
   import { createEventDispatcher } from 'svelte';
 
   export let id = '';
+  export let file: File | null = null;
+
+  let files: FileList | null = null;
 
   const dispatch = createEventDispatcher();
-
-  let files: FileList;
 
   $: if (files) {
     dispatch('change', { file: files[0] });
@@ -23,8 +24,8 @@
   />
   <span
     class="file-prompt"
-    class:file-prompt--uploaded={files?.[0].name}
-    data-content={files?.[0]?.name ?? 'Choose file...'}
+    class:file-prompt--uploaded={file?.name}
+    data-content={file?.name ?? 'Choose file...'}
   />
 </label>
 

--- a/src/lib/components/shared/MenuItem.svelte
+++ b/src/lib/components/shared/MenuItem.svelte
@@ -5,16 +5,16 @@
   export let titleClass = '';
 </script>
 
-<div class="stack stack-xs p-4 font-mono text-xs text-white">
+<div class="stack stack-2xs p-4 font-mono text-xs text-white">
   {#if $$slots.action}
     <div class={cs('flex items-center justify-between', titleClass)}>
-      <p class="font-sans text-base font-medium tracking-wider">
+      <p class="font-sans text-sm font-medium tracking-wider">
         {title}
       </p>
       <slot name="action" />
     </div>
   {:else}
-    <p class="font-sans text-base font-medium tracking-wider">
+    <p class="font-sans text-sm font-medium tracking-wider">
       {title}
     </p>
   {/if}

--- a/src/lib/components/shared/MenuTitle.svelte
+++ b/src/lib/components/shared/MenuTitle.svelte
@@ -8,7 +8,7 @@
 {#if $$slots.action && $$slots.subtitle}
   <div class="stack stack-xs p-4 text-white">
     <div class="flex items-center justify-between">
-      <p class={cs('font-sans text-xl font-medium tracking-wider', className)}>
+      <p class={cs('font-sans text-lg font-medium tracking-wider', className)}>
         <slot />
       </p>
       <slot name="action" />

--- a/src/lib/components/size/SizeControls.svelte
+++ b/src/lib/components/size/SizeControls.svelte
@@ -22,14 +22,26 @@
   }
 </script>
 
-<div class="stack stack-xs">
+<div class="stack stack-2xs">
   <AttributeSelect {layer} selected={layer.style.size.attribute} />
   <div class="stack-h stack-h-xs items-center">
     <FieldLabel fieldId="min">Min</FieldLabel>
-    <NumberInput id="min" min={1} value={min} on:change={onSizeChange('min')} />
+    <NumberInput
+      id="min"
+      min={1}
+      value={min}
+      on:change={onSizeChange('min')}
+      class="w-10"
+    />
   </div>
   <div class="stack-h stack-h-xs items-center">
     <FieldLabel fieldId="max">Max</FieldLabel>
-    <NumberInput id="max" min={1} value={max} on:change={onSizeChange('max')} />
+    <NumberInput
+      id="max"
+      min={1}
+      value={max}
+      on:change={onSizeChange('max')}
+      class="w-10"
+    />
   </div>
 </div>


### PR DESCRIPTION
This PR reduces the font size and spacing of the Properties Panel to maximize screen real estate. While looking around at other design tool interfaces, I noticed `cartokit` seemed to be occupying a lot more space with UI elements while doing a lot less. A primary culprit seemed to be the font size and spacing in use on the Properties Panel. With this change, we get a bit of space back—especially for map types with more configuration options!

| Before | After |
|--------|--------|
| <img width="1552" alt="cartokit before reducing the font size and spacing in the Properties Panel." src="https://github.com/parkerziegler/cartokit/assets/19421190/f1d25a8a-2279-4c25-b029-39804996af3f"> | <img width="1552" alt="cartokit with reduced font size and spacing in the Properties Panel." src="https://github.com/parkerziegler/cartokit/assets/19421190/bd8ee296-bbf0-4f26-a1e6-8a2ae00a7baf"> |

In addition, I snuck in a tiny bug fix to ensure our `FileInput` component will properly clear the selected file on form submission.