### PR TITLE
fix: Make DataTable full width.

### DIFF
--- a/src/lib/components/shared/DataTable.svelte
+++ b/src/lib/components/shared/DataTable.svelte
@@ -31,13 +31,13 @@
   let n = Math.min(N, Math.floor(rows * 2)); // The number of rows displayed.
   let sort = { col: '', desc: true };
 
-  const minlengthof = (length: number) => {
+  function minlengthof(length: number) {
     length = Math.floor(length);
 
     return Math.min(N, length);
-  };
+  }
 
-  const materialize = (data: Feature[]) => {
+  function materialize(data: Feature[]) {
     // Empty array and reinstantiate the iterator and n.
     array = [];
     iterator = data[Symbol.iterator]();
@@ -48,9 +48,9 @@
 
     // Scroll to the top.
     root.scrollTo(root.scrollLeft, 0);
-  };
+  }
 
-  const appendRows = (start: number, end: number) => {
+  function appendRows(start: number, end: number) {
     for (; start < end; start++) {
       const { done, value } = iterator.next();
 
@@ -61,9 +61,9 @@
       array.push(value);
     }
     array = array;
-  };
+  }
 
-  const resort = (col: string) => {
+  function resort(col: string) {
     return () => {
       sort = {
         col,
@@ -76,16 +76,16 @@
 
       materialize(d);
     };
-  };
+  }
 
-  const onScroll = () => {
+  function onScroll() {
     if (
       root.scrollHeight - root.scrollTop < rows * ROW_HEIGHT * 1.5 &&
       n < minlengthof(n + 1)
     ) {
       appendRows(n, (n = minlengthof(n + rows)));
     }
-  };
+  }
 
   onMount(() => {
     appendRows(0, n);
@@ -116,7 +116,7 @@
     bind:this={root}
     on:scroll={onScroll}
   >
-    <table class="border-collapse">
+    <table class="w-full border-collapse">
       <thead>
         <tr class="sticky top-0">
           {#each cols as col}


### PR DESCRIPTION
This PR makes our `DataTable` implementation full width. Previously, narrow tables would only occupy the space they needed rather than stretching to fill available space. With this change, narrow tables occupy 100% of the viewport; wide tables simplify overflow the viewport as they did before.

| Before | After |
|--------|--------|
| <img width="2032" alt="The cartokit DataTable before the changes in this PR." src="https://github.com/parkerziegler/cartokit/assets/19421190/a8372975-6574-42dc-a687-1b108dab2f7f"> | <img width="2032" alt="The cartokit DataTable after the changes in this PR." src="https://github.com/parkerziegler/cartokit/assets/19421190/f1991543-42e0-43a1-8147-42074c4a2ce0"> | 

