### PR TITLE
fix: Fix regression in ColorSchemeSelect.

### DIFF
--- a/src/lib/components/color/ColorSchemeSelect.svelte
+++ b/src/lib/components/color/ColorSchemeSelect.svelte
@@ -101,14 +101,14 @@
                 class="first-scheme px-4 py-2 hover:bg-slate-600"
                 bind:this={firstScheme}
               >
-                <ColorSchemeList {colors} />
+                <ColorSchemeList colors={scheme[layer.style.fill.count]} />
               </button>
             {:else}
               <button
                 on:click={() => onSchemeSelect(scheme)}
                 class="px-4 py-2 hover:bg-slate-600"
               >
-                <ColorSchemeList {colors} />
+                <ColorSchemeList colors={scheme[layer.style.fill.count]} />
               </button>
             {/if}
           {/each}


### PR DESCRIPTION
This PR addresses a small regression introduced in #318. Currently on `alpha.cartokit.dev`, all available color schemes rendered by `ColorSchemeSelect` are the same scheme. This PR restores full choice of color scheme 😅 

| Before | After |
|--------|--------|
| <img width="1552" alt="A screenshot of the ColorSchemeSelect bug on alpha.cartokit.dev. All available color schemes are the same scheme." src="https://github.com/user-attachments/assets/edda967b-52c6-4b75-a852-5e67f4de6610"> | <img width="1552" alt="A screenshot of the ColorSchemeSelect fix on localhost. Full choice of color schemes has been restored." src="https://github.com/user-attachments/assets/3c5d46b5-ad6e-4226-bf95-0ecf66ab6783"> | 