### PR TITLE
fix: Prevent <vercel-live-feedback> element from intercepting click on Open Editor button in Preview environments.

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -24,7 +24,6 @@ jobs:
         run: pnpm exec playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
         env:
           PLAYWRIGHT_TEST_BASE_URL: ${{ github.event.deployment_status.environment == 'production' && 'https://alpha.cartokit.dev/' || github.event.deployment_status.target_url }}
-          GITHUB_ENV: ${{ github.event.deployment_status.environment }}
       - name: Upload blob report to GitHub Actions Artifacts
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -24,6 +24,7 @@ jobs:
         run: pnpm exec playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
         env:
           PLAYWRIGHT_TEST_BASE_URL: ${{ github.event.deployment_status.environment == 'production' && 'https://alpha.cartokit.dev/' || github.event.deployment_status.target_url }}
+          VERCEL_ENV: ${{ github.event.deployment_status.environment }}
       - name: Upload blob report to GitHub Actions Artifacts
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -24,7 +24,7 @@ jobs:
         run: pnpm exec playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
         env:
           PLAYWRIGHT_TEST_BASE_URL: ${{ github.event.deployment_status.environment == 'production' && 'https://alpha.cartokit.dev/' || github.event.deployment_status.target_url }}
-          VERCEL_ENV: ${{ github.event.deployment_status.environment }}
+          GITHUB_ENV: ${{ github.event.deployment_status.environment }}
       - name: Upload blob report to GitHub Actions Artifacts
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}

--- a/tests/workflows/workflow-1.spec.ts
+++ b/tests/workflows/workflow-1.spec.ts
@@ -33,9 +33,11 @@ test('workflow-1', async ({ page }) => {
   if (process.env.GITHUB_ENV === 'Preview') {
     // In Preview Vercel environments, ensure <vercel-live-feedback> does not
     // intercept pointer events.
-    await page
-      .locator('vercel-live-feedback')
-      .evaluate((element) => (element.style.pointerEvents = 'none'));
+    await page.locator('vercel-live-feedback').waitFor({ state: 'attached' });
+    await page.locator('vercel-live-feedback').evaluate((element) => {
+      element.style.pointerEvents = 'none';
+      element.style.zIndex = '-1';
+    });
   }
 
   // Wait for the Open Editor button and Add Layer button to become enabled. These

--- a/tests/workflows/workflow-1.spec.ts
+++ b/tests/workflows/workflow-1.spec.ts
@@ -30,7 +30,7 @@ test('workflow-1', async ({ page }) => {
   // Navigate to cartokit, running on a local development server.
   await page.goto('/');
 
-  if (process.env.VERCEL_ENV === 'preview') {
+  if (process.env.VERCEL_ENV === 'Preview') {
     // In Preview Vercel environments, ensure <vercel-live-feedback> does not
     // intercept pointer events.
     await page

--- a/tests/workflows/workflow-1.spec.ts
+++ b/tests/workflows/workflow-1.spec.ts
@@ -30,7 +30,7 @@ test('workflow-1', async ({ page }) => {
   // Navigate to cartokit, running on a local development server.
   await page.goto('/');
 
-  if (process.env.VERCEL_ENV === 'Preview') {
+  if (process.env.GITHUB_ENV === 'Preview') {
     // In Preview Vercel environments, ensure <vercel-live-feedback> does not
     // intercept pointer events.
     await page

--- a/tests/workflows/workflow-1.spec.ts
+++ b/tests/workflows/workflow-1.spec.ts
@@ -29,6 +29,7 @@ test('workflow-1', async ({ page }) => {
 
   // Navigate to cartokit, running on a local development server.
   await page.goto('/');
+  console.log(process.env);
 
   if (process.env.GITHUB_ENV === 'Preview') {
     // In Preview Vercel environments, ensure <vercel-live-feedback> does not
@@ -37,6 +38,7 @@ test('workflow-1', async ({ page }) => {
     await page.locator('vercel-live-feedback').evaluate((element) => {
       element.style.pointerEvents = 'none';
       element.style.zIndex = '-1';
+      element.style.display = 'none';
     });
   }
 

--- a/tests/workflows/workflow-1.spec.ts
+++ b/tests/workflows/workflow-1.spec.ts
@@ -30,6 +30,14 @@ test('workflow-1', async ({ page }) => {
   // Navigate to cartokit, running on a local development server.
   await page.goto('/');
 
+  if (process.env.VERCEL_ENV === 'preview') {
+    // In Preview Vercel environments, ensure <vercel-live-feedback> does not
+    // intercept pointer events.
+    await page
+      .locator('vercel-live-feedback')
+      .evaluate((element) => (element.style.pointerEvents = 'none'));
+  }
+
   // Wait for the Open Editor button and Add Layer button to become enabled. These
   // are proxies for the map reaching an idle state.
   await expect(page.getByTestId('editor-toggle')).toBeEnabled({

--- a/tests/workflows/workflow-1.spec.ts
+++ b/tests/workflows/workflow-1.spec.ts
@@ -31,7 +31,7 @@ test('workflow-1', async ({ page }) => {
   await page.goto('/');
   console.log(process.env);
 
-  if (process.env.GITHUB_ENV === 'Preview') {
+  if (page.url().includes('vercel.app')) {
     // In Preview Vercel environments, ensure <vercel-live-feedback> does not
     // intercept pointer events.
     await page.locator('vercel-live-feedback').waitFor({ state: 'attached' });

--- a/tests/workflows/workflow-1.spec.ts
+++ b/tests/workflows/workflow-1.spec.ts
@@ -29,7 +29,6 @@ test('workflow-1', async ({ page }) => {
 
   // Navigate to cartokit, running on a local development server.
   await page.goto('/');
-  console.log(process.env);
 
   if (page.url().includes('vercel.app')) {
     // In Preview Vercel environments, ensure <vercel-live-feedback> does not

--- a/tests/workflows/workflow-2.spec.ts
+++ b/tests/workflows/workflow-2.spec.ts
@@ -75,7 +75,7 @@ test('workflow-2', async ({ page }) => {
   // Navigate to cartokit, running on a local development server.
   await page.goto('/');
 
-  if (process.env.VERCEL_ENV === 'preview') {
+  if (process.env.VERCEL_ENV === 'Preview') {
     // In Preview Vercel environments, ensure <vercel-live-feedback> does not
     // intercept pointer events.
     await page

--- a/tests/workflows/workflow-2.spec.ts
+++ b/tests/workflows/workflow-2.spec.ts
@@ -75,6 +75,14 @@ test('workflow-2', async ({ page }) => {
   // Navigate to cartokit, running on a local development server.
   await page.goto('/');
 
+  if (process.env.VERCEL_ENV === 'preview') {
+    // In Preview Vercel environments, ensure <vercel-live-feedback> does not
+    // intercept pointer events.
+    await page
+      .locator('vercel-live-feedback')
+      .evaluate((element) => (element.style.pointerEvents = 'none'));
+  }
+
   // Wait for the Open Editor button and Add Layer button to become enabled. These
   // are proxies for the map reaching an idle state.
   await expect(page.getByTestId('editor-toggle')).toBeEnabled({

--- a/tests/workflows/workflow-2.spec.ts
+++ b/tests/workflows/workflow-2.spec.ts
@@ -74,7 +74,6 @@ test('workflow-2', async ({ page }) => {
 
   // Navigate to cartokit, running on a local development server.
   await page.goto('/');
-  console.log(process.env);
 
   if (page.url().includes('vercel.app')) {
     // In Preview Vercel environments, ensure <vercel-live-feedback> does not

--- a/tests/workflows/workflow-2.spec.ts
+++ b/tests/workflows/workflow-2.spec.ts
@@ -78,9 +78,11 @@ test('workflow-2', async ({ page }) => {
   if (process.env.GITHUB_ENV === 'Preview') {
     // In Preview Vercel environments, ensure <vercel-live-feedback> does not
     // intercept pointer events.
-    await page
-      .locator('vercel-live-feedback')
-      .evaluate((element) => (element.style.pointerEvents = 'none'));
+    await page.locator('vercel-live-feedback').waitFor({ state: 'attached' });
+    await page.locator('vercel-live-feedback').evaluate((element) => {
+      element.style.pointerEvents = 'none';
+      element.style.zIndex = '-1';
+    });
   }
 
   // Wait for the Open Editor button and Add Layer button to become enabled. These

--- a/tests/workflows/workflow-2.spec.ts
+++ b/tests/workflows/workflow-2.spec.ts
@@ -74,6 +74,7 @@ test('workflow-2', async ({ page }) => {
 
   // Navigate to cartokit, running on a local development server.
   await page.goto('/');
+  console.log(process.env);
 
   if (process.env.GITHUB_ENV === 'Preview') {
     // In Preview Vercel environments, ensure <vercel-live-feedback> does not
@@ -82,6 +83,7 @@ test('workflow-2', async ({ page }) => {
     await page.locator('vercel-live-feedback').evaluate((element) => {
       element.style.pointerEvents = 'none';
       element.style.zIndex = '-1';
+      element.style.display = 'none';
     });
   }
 

--- a/tests/workflows/workflow-2.spec.ts
+++ b/tests/workflows/workflow-2.spec.ts
@@ -76,7 +76,7 @@ test('workflow-2', async ({ page }) => {
   await page.goto('/');
   console.log(process.env);
 
-  if (process.env.GITHUB_ENV === 'Preview') {
+  if (page.url().includes('vercel.app')) {
     // In Preview Vercel environments, ensure <vercel-live-feedback> does not
     // intercept pointer events.
     await page.locator('vercel-live-feedback').waitFor({ state: 'attached' });

--- a/tests/workflows/workflow-2.spec.ts
+++ b/tests/workflows/workflow-2.spec.ts
@@ -75,7 +75,7 @@ test('workflow-2', async ({ page }) => {
   // Navigate to cartokit, running on a local development server.
   await page.goto('/');
 
-  if (process.env.VERCEL_ENV === 'Preview') {
+  if (process.env.GITHUB_ENV === 'Preview') {
     // In Preview Vercel environments, ensure <vercel-live-feedback> does not
     // intercept pointer events.
     await page

--- a/tests/workflows/workflow-3.spec.ts
+++ b/tests/workflows/workflow-3.spec.ts
@@ -79,7 +79,7 @@ test('workflow-3', async ({ page }) => {
   await page.goto('/');
   console.log(process.env);
 
-  if (process.env.GITHUB_ENV === 'Preview') {
+  if (page.url().includes('vercel.app')) {
     // In Preview Vercel environments, ensure <vercel-live-feedback> does not
     // intercept pointer events.
     await page.locator('vercel-live-feedback').waitFor({ state: 'attached' });

--- a/tests/workflows/workflow-3.spec.ts
+++ b/tests/workflows/workflow-3.spec.ts
@@ -78,6 +78,14 @@ test('workflow-3', async ({ page }) => {
   // Navigate to cartokit, running on a local development server.
   await page.goto('/');
 
+  if (process.env.VERCEL_ENV === 'preview') {
+    // In Preview Vercel environments, ensure <vercel-live-feedback> does not
+    // intercept pointer events.
+    await page
+      .locator('vercel-live-feedback')
+      .evaluate((element) => (element.style.pointerEvents = 'none'));
+  }
+
   // Wait for the Open Editor button and Add Layer button to become enabled. These
   // are proxies for the map reaching an idle state.
   await expect(page.getByTestId('editor-toggle')).toBeEnabled({

--- a/tests/workflows/workflow-3.spec.ts
+++ b/tests/workflows/workflow-3.spec.ts
@@ -78,7 +78,7 @@ test('workflow-3', async ({ page }) => {
   // Navigate to cartokit, running on a local development server.
   await page.goto('/');
 
-  if (process.env.VERCEL_ENV === 'preview') {
+  if (process.env.VERCEL_ENV === 'Preview') {
     // In Preview Vercel environments, ensure <vercel-live-feedback> does not
     // intercept pointer events.
     await page

--- a/tests/workflows/workflow-3.spec.ts
+++ b/tests/workflows/workflow-3.spec.ts
@@ -77,6 +77,7 @@ test('workflow-3', async ({ page }) => {
 
   // Navigate to cartokit, running on a local development server.
   await page.goto('/');
+  console.log(process.env);
 
   if (process.env.GITHUB_ENV === 'Preview') {
     // In Preview Vercel environments, ensure <vercel-live-feedback> does not
@@ -85,6 +86,7 @@ test('workflow-3', async ({ page }) => {
     await page.locator('vercel-live-feedback').evaluate((element) => {
       element.style.pointerEvents = 'none';
       element.style.zIndex = '-1';
+      element.style.display = 'none';
     });
   }
 

--- a/tests/workflows/workflow-3.spec.ts
+++ b/tests/workflows/workflow-3.spec.ts
@@ -77,7 +77,6 @@ test('workflow-3', async ({ page }) => {
 
   // Navigate to cartokit, running on a local development server.
   await page.goto('/');
-  console.log(process.env);
 
   if (page.url().includes('vercel.app')) {
     // In Preview Vercel environments, ensure <vercel-live-feedback> does not

--- a/tests/workflows/workflow-3.spec.ts
+++ b/tests/workflows/workflow-3.spec.ts
@@ -81,9 +81,11 @@ test('workflow-3', async ({ page }) => {
   if (process.env.GITHUB_ENV === 'Preview') {
     // In Preview Vercel environments, ensure <vercel-live-feedback> does not
     // intercept pointer events.
-    await page
-      .locator('vercel-live-feedback')
-      .evaluate((element) => (element.style.pointerEvents = 'none'));
+    await page.locator('vercel-live-feedback').waitFor({ state: 'attached' });
+    await page.locator('vercel-live-feedback').evaluate((element) => {
+      element.style.pointerEvents = 'none';
+      element.style.zIndex = '-1';
+    });
   }
 
   // Wait for the Open Editor button and Add Layer button to become enabled. These

--- a/tests/workflows/workflow-3.spec.ts
+++ b/tests/workflows/workflow-3.spec.ts
@@ -78,7 +78,7 @@ test('workflow-3', async ({ page }) => {
   // Navigate to cartokit, running on a local development server.
   await page.goto('/');
 
-  if (process.env.VERCEL_ENV === 'Preview') {
+  if (process.env.GITHUB_ENV === 'Preview') {
     // In Preview Vercel environments, ensure <vercel-live-feedback> does not
     // intercept pointer events.
     await page

--- a/tests/workflows/workflow-4.spec.ts
+++ b/tests/workflows/workflow-4.spec.ts
@@ -27,6 +27,14 @@ test('workflow-4', async ({ page }) => {
   // Navigate to cartokit, running on a local development server.
   await page.goto('/');
 
+  if (process.env.VERCEL_ENV === 'preview') {
+    // In Preview Vercel environments, ensure <vercel-live-feedback> does not
+    // intercept pointer events.
+    await page
+      .locator('vercel-live-feedback')
+      .evaluate((element) => (element.style.pointerEvents = 'none'));
+  }
+
   // Wait for the Open Editor button and Add Layer button to become enabled. These
   // are proxies for the map reaching an idle state.
   await expect(page.getByTestId('editor-toggle')).toBeEnabled({

--- a/tests/workflows/workflow-4.spec.ts
+++ b/tests/workflows/workflow-4.spec.ts
@@ -26,7 +26,6 @@ test('workflow-4', async ({ page }) => {
 
   // Navigate to cartokit, running on a local development server.
   await page.goto('/');
-  console.log(process.env);
 
   if (page.url().includes('vercel.app')) {
     // In Preview Vercel environments, ensure <vercel-live-feedback> does not

--- a/tests/workflows/workflow-4.spec.ts
+++ b/tests/workflows/workflow-4.spec.ts
@@ -26,6 +26,7 @@ test('workflow-4', async ({ page }) => {
 
   // Navigate to cartokit, running on a local development server.
   await page.goto('/');
+  console.log(process.env);
 
   if (process.env.GITHUB_ENV === 'Preview') {
     // In Preview Vercel environments, ensure <vercel-live-feedback> does not
@@ -34,6 +35,7 @@ test('workflow-4', async ({ page }) => {
     await page.locator('vercel-live-feedback').evaluate((element) => {
       element.style.pointerEvents = 'none';
       element.style.zIndex = '-1';
+      element.style.display = 'none';
     });
   }
 

--- a/tests/workflows/workflow-4.spec.ts
+++ b/tests/workflows/workflow-4.spec.ts
@@ -30,9 +30,11 @@ test('workflow-4', async ({ page }) => {
   if (process.env.GITHUB_ENV === 'Preview') {
     // In Preview Vercel environments, ensure <vercel-live-feedback> does not
     // intercept pointer events.
-    await page
-      .locator('vercel-live-feedback')
-      .evaluate((element) => (element.style.pointerEvents = 'none'));
+    await page.locator('vercel-live-feedback').waitFor({ state: 'attached' });
+    await page.locator('vercel-live-feedback').evaluate((element) => {
+      element.style.pointerEvents = 'none';
+      element.style.zIndex = '-1';
+    });
   }
 
   // Wait for the Open Editor button and Add Layer button to become enabled. These

--- a/tests/workflows/workflow-4.spec.ts
+++ b/tests/workflows/workflow-4.spec.ts
@@ -27,7 +27,7 @@ test('workflow-4', async ({ page }) => {
   // Navigate to cartokit, running on a local development server.
   await page.goto('/');
 
-  if (process.env.VERCEL_ENV === 'Preview') {
+  if (process.env.GITHUB_ENV === 'Preview') {
     // In Preview Vercel environments, ensure <vercel-live-feedback> does not
     // intercept pointer events.
     await page

--- a/tests/workflows/workflow-4.spec.ts
+++ b/tests/workflows/workflow-4.spec.ts
@@ -28,7 +28,7 @@ test('workflow-4', async ({ page }) => {
   await page.goto('/');
   console.log(process.env);
 
-  if (process.env.GITHUB_ENV === 'Preview') {
+  if (page.url().includes('vercel.app')) {
     // In Preview Vercel environments, ensure <vercel-live-feedback> does not
     // intercept pointer events.
     await page.locator('vercel-live-feedback').waitFor({ state: 'attached' });

--- a/tests/workflows/workflow-4.spec.ts
+++ b/tests/workflows/workflow-4.spec.ts
@@ -27,7 +27,7 @@ test('workflow-4', async ({ page }) => {
   // Navigate to cartokit, running on a local development server.
   await page.goto('/');
 
-  if (process.env.VERCEL_ENV === 'preview') {
+  if (process.env.VERCEL_ENV === 'Preview') {
     // In Preview Vercel environments, ensure <vercel-live-feedback> does not
     // intercept pointer events.
     await page

--- a/tests/workflows/workflow-5.spec.ts
+++ b/tests/workflows/workflow-5.spec.ts
@@ -30,7 +30,7 @@ test('workflow-5', async ({ page }) => {
   // Navigate to cartokit, running on a local development server.
   await page.goto('/');
 
-  if (process.env.VERCEL_ENV === 'preview') {
+  if (process.env.VERCEL_ENV === 'Preview') {
     // In Preview Vercel environments, ensure <vercel-live-feedback> does not
     // intercept pointer events.
     await page

--- a/tests/workflows/workflow-5.spec.ts
+++ b/tests/workflows/workflow-5.spec.ts
@@ -33,9 +33,11 @@ test('workflow-5', async ({ page }) => {
   if (process.env.GITHUB_ENV === 'Preview') {
     // In Preview Vercel environments, ensure <vercel-live-feedback> does not
     // intercept pointer events.
-    await page
-      .locator('vercel-live-feedback')
-      .evaluate((element) => (element.style.pointerEvents = 'none'));
+    await page.locator('vercel-live-feedback').waitFor({ state: 'attached' });
+    await page.locator('vercel-live-feedback').evaluate((element) => {
+      element.style.pointerEvents = 'none';
+      element.style.zIndex = '-1';
+    });
   }
 
   // Wait for the Open Editor button and Add Layer button to become enabled. These

--- a/tests/workflows/workflow-5.spec.ts
+++ b/tests/workflows/workflow-5.spec.ts
@@ -30,6 +30,14 @@ test('workflow-5', async ({ page }) => {
   // Navigate to cartokit, running on a local development server.
   await page.goto('/');
 
+  if (process.env.VERCEL_ENV === 'preview') {
+    // In Preview Vercel environments, ensure <vercel-live-feedback> does not
+    // intercept pointer events.
+    await page
+      .locator('vercel-live-feedback')
+      .evaluate((element) => (element.style.pointerEvents = 'none'));
+  }
+
   // Wait for the Open Editor button and Add Layer button to become enabled. These
   // are proxies for the map reaching an idle state.
   await expect(page.getByTestId('editor-toggle')).toBeEnabled({

--- a/tests/workflows/workflow-5.spec.ts
+++ b/tests/workflows/workflow-5.spec.ts
@@ -30,7 +30,7 @@ test('workflow-5', async ({ page }) => {
   // Navigate to cartokit, running on a local development server.
   await page.goto('/');
 
-  if (process.env.VERCEL_ENV === 'Preview') {
+  if (process.env.GITHUB_ENV === 'Preview') {
     // In Preview Vercel environments, ensure <vercel-live-feedback> does not
     // intercept pointer events.
     await page

--- a/tests/workflows/workflow-5.spec.ts
+++ b/tests/workflows/workflow-5.spec.ts
@@ -29,7 +29,6 @@ test('workflow-5', async ({ page }) => {
 
   // Navigate to cartokit, running on a local development server.
   await page.goto('/');
-  console.log(process.env);
 
   if (page.url().includes('vercel.app')) {
     // In Preview Vercel environments, ensure <vercel-live-feedback> does not

--- a/tests/workflows/workflow-5.spec.ts
+++ b/tests/workflows/workflow-5.spec.ts
@@ -31,7 +31,7 @@ test('workflow-5', async ({ page }) => {
   await page.goto('/');
   console.log(process.env);
 
-  if (process.env.GITHUB_ENV === 'Preview') {
+  if (page.url().includes('vercel.app')) {
     // In Preview Vercel environments, ensure <vercel-live-feedback> does not
     // intercept pointer events.
     await page.locator('vercel-live-feedback').waitFor({ state: 'attached' });

--- a/tests/workflows/workflow-5.spec.ts
+++ b/tests/workflows/workflow-5.spec.ts
@@ -29,6 +29,7 @@ test('workflow-5', async ({ page }) => {
 
   // Navigate to cartokit, running on a local development server.
   await page.goto('/');
+  console.log(process.env);
 
   if (process.env.GITHUB_ENV === 'Preview') {
     // In Preview Vercel environments, ensure <vercel-live-feedback> does not
@@ -37,6 +38,7 @@ test('workflow-5', async ({ page }) => {
     await page.locator('vercel-live-feedback').evaluate((element) => {
       element.style.pointerEvents = 'none';
       element.style.zIndex = '-1';
+      element.style.display = 'none';
     });
   }
 

--- a/tests/workflows/workflow-6.spec.ts
+++ b/tests/workflows/workflow-6.spec.ts
@@ -31,7 +31,7 @@ test('workflow-6', async ({ page }) => {
     'https://cartokit-zetq-65nem620w-parker-zieglers-projects.vercel.app/'
   );
 
-  if (process.env.VERCEL_ENV === 'Preview') {
+  if (process.env.GITHUB_ENV === 'Preview') {
     // In Preview Vercel environments, ensure <vercel-live-feedback> does not
     // intercept pointer events.
     await page

--- a/tests/workflows/workflow-6.spec.ts
+++ b/tests/workflows/workflow-6.spec.ts
@@ -27,16 +27,16 @@ test('workflow-6', async ({ page }) => {
   test.slow();
 
   // Navigate to cartokit, running on a local development server.
-  await page.goto(
-    'https://cartokit-zetq-65nem620w-parker-zieglers-projects.vercel.app/'
-  );
+  await page.goto('/');
 
   if (process.env.GITHUB_ENV === 'Preview') {
     // In Preview Vercel environments, ensure <vercel-live-feedback> does not
     // intercept pointer events.
-    await page
-      .locator('vercel-live-feedback')
-      .evaluate((element) => (element.style.pointerEvents = 'none'));
+    await page.locator('vercel-live-feedback').waitFor({ state: 'attached' });
+    await page.locator('vercel-live-feedback').evaluate((element) => {
+      element.style.pointerEvents = 'none';
+      element.style.zIndex = '-1';
+    });
   }
 
   // Wait for the Open Editor button and Add Layer button to become enabled. These

--- a/tests/workflows/workflow-6.spec.ts
+++ b/tests/workflows/workflow-6.spec.ts
@@ -31,7 +31,7 @@ test('workflow-6', async ({ page }) => {
     'https://cartokit-zetq-65nem620w-parker-zieglers-projects.vercel.app/'
   );
 
-  if (process.env.VERCEL_ENV === 'preview') {
+  if (process.env.VERCEL_ENV === 'Preview') {
     // In Preview Vercel environments, ensure <vercel-live-feedback> does not
     // intercept pointer events.
     await page

--- a/tests/workflows/workflow-6.spec.ts
+++ b/tests/workflows/workflow-6.spec.ts
@@ -28,9 +28,8 @@ test('workflow-6', async ({ page }) => {
 
   // Navigate to cartokit, running on a local development server.
   await page.goto('/');
-  console.log(process.env);
 
-  if (process.env.GITHUB_ENV === 'Preview') {
+  if (page.url().includes('vercel.app')) {
     // In Preview Vercel environments, ensure <vercel-live-feedback> does not
     // intercept pointer events.
     await page.locator('vercel-live-feedback').waitFor({ state: 'attached' });

--- a/tests/workflows/workflow-6.spec.ts
+++ b/tests/workflows/workflow-6.spec.ts
@@ -28,6 +28,7 @@ test('workflow-6', async ({ page }) => {
 
   // Navigate to cartokit, running on a local development server.
   await page.goto('/');
+  console.log(process.env);
 
   if (process.env.GITHUB_ENV === 'Preview') {
     // In Preview Vercel environments, ensure <vercel-live-feedback> does not
@@ -36,6 +37,7 @@ test('workflow-6', async ({ page }) => {
     await page.locator('vercel-live-feedback').evaluate((element) => {
       element.style.pointerEvents = 'none';
       element.style.zIndex = '-1';
+      element.style.display = 'none';
     });
   }
 

--- a/tests/workflows/workflow-6.spec.ts
+++ b/tests/workflows/workflow-6.spec.ts
@@ -27,7 +27,17 @@ test('workflow-6', async ({ page }) => {
   test.slow();
 
   // Navigate to cartokit, running on a local development server.
-  await page.goto('/');
+  await page.goto(
+    'https://cartokit-zetq-65nem620w-parker-zieglers-projects.vercel.app/'
+  );
+
+  if (process.env.VERCEL_ENV === 'preview') {
+    // In Preview Vercel environments, ensure <vercel-live-feedback> does not
+    // intercept pointer events.
+    await page
+      .locator('vercel-live-feedback')
+      .evaluate((element) => (element.style.pointerEvents = 'none'));
+  }
 
   // Wait for the Open Editor button and Add Layer button to become enabled. These
   // are proxies for the map reaching an idle state.


### PR DESCRIPTION
This PR fixes an extremely annoying bug 😅 In our Vercel Preview environments—which are also the environments we run our e2e tests against—there is a `<vercel-live-feedback>` [custom element](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_custom_elements). This element intercepts all pointer events due to its ludicrously high z-index and its setting of `pointer-events: auto` on its first child. Therefore, our tests time out waiting for  the first click on the **Open Editor** `button`—Playwright's actionability check determines that `<vercel-live-feedback>` intercepts the click.

To address this, we now directly modify the `pointer-events`, `z-index`, and `display` properties of the `<vercel-live-feedback>` element for tests running in Preview environments. Interestingly, this bug only seems to affect tests running on WebKit 🤔 