### PR TITLE
feat: Add initial implementation for undo and redo.

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,7 @@ importers:
         version: 3.5.2
       recast:
         specifier: ^0.23.9
-        version: 0.23.9
+        version: 0.23.10
       simple-statistics:
         specifier: ^7.8.7
         version: 7.8.7
@@ -2095,8 +2095,8 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
-  recast@0.23.9:
-    resolution: {integrity: sha512-Hx/BGIbwj+Des3+xy5uAtAbdCyqK9y9wbBcDFDYanLS9JnMqf7OeF87HQwUimE87OEc72mr6tkKUKMBBL+hF9Q==}
+  recast@0.23.10:
+    resolution: {integrity: sha512-mbCmRMJUKCJ1h41V0cu2C26ULBURwuoZ34C9rChjcDaeJ/4Kv5al3O2HPwTs2m0wQ1vGhMY+tguhzU1aE8md1A==}
     engines: {node: '>= 4'}
 
   resolve-from@4.0.0:
@@ -4287,7 +4287,7 @@ snapshots:
 
   readdirp@4.1.2: {}
 
-  recast@0.23.9:
+  recast@0.23.10:
     dependencies:
       ast-types: 0.16.1
       esprima: 4.0.1

--- a/src/lib/components/classification/ClassificationMethodSelect.svelte
+++ b/src/lib/components/classification/ClassificationMethodSelect.svelte
@@ -7,6 +7,7 @@
   import { dispatchLayerUpdate } from '$lib/interaction/update';
   import type { ClassificationMethod, QuantitativeStyle } from '$lib/types';
   import { CLASSIFICATION_METHODS } from '$lib/utils/classification';
+  import { history } from '$lib/state/history.svelte';
 
   interface Props {
     layerId: string;
@@ -37,13 +38,26 @@
       displayBreaksEditor = false;
     }
 
-    dispatchLayerUpdate({
-      type: 'classification-method',
+    const update = {
+      type: 'classification-method' as const,
       layerId,
       payload: {
         method: event.currentTarget.value as ClassificationMethod
       }
+    };
+
+    history.undo.push({
+      execute: update,
+      invert: {
+        type: 'classification-method',
+        layerId,
+        payload: {
+          method: style.method
+        }
+      }
     });
+
+    dispatchLayerUpdate(update);
   }
 
   function toggleBreaksEditorVisibility() {

--- a/src/lib/components/color/ColorSchemeSelect.svelte
+++ b/src/lib/components/color/ColorSchemeSelect.svelte
@@ -4,6 +4,7 @@
   import FieldLabel from '$lib/components/shared/FieldLabel.svelte';
   import Portal from '$lib/components/shared/Portal.svelte';
   import { dispatchLayerUpdate } from '$lib/interaction/update';
+  import { history } from '$lib/state/history.svelte';
   import type {
     CategoricalColorScheme,
     QuantitativeColorScheme,
@@ -56,20 +57,37 @@
     showOptions = false;
   }
 
-  function onClickScheme(
+  function dispatchSchemeUpdate(
     scheme: CategoricalColorScheme | QuantitativeColorScheme
   ) {
-    return function handleSchemeSelect() {
-      dispatchLayerUpdate({
+    const update = {
+      type: 'color-scheme' as const,
+      layerId,
+      payload: {
+        scheme
+      }
+    };
+
+    history.undo.push({
+      execute: update,
+      invert: {
         type: 'color-scheme',
         layerId,
         payload: {
-          scheme
+          scheme: style.scheme
         }
-      });
+      }
+    });
 
-      showOptions = false;
-    };
+    dispatchLayerUpdate(update);
+  }
+
+  function onClickScheme(
+    scheme: CategoricalColorScheme | QuantitativeColorScheme
+  ) {
+    showOptions = false;
+
+    dispatchSchemeUpdate(scheme);
   }
 
   function onSchemeReverse() {
@@ -80,13 +98,7 @@
         ? reverseQuantitativeColorScheme(style.scheme)
         : reverseCategoricalColorScheme(style.scheme);
 
-    dispatchLayerUpdate({
-      type: 'color-scheme',
-      layerId,
-      payload: {
-        scheme
-      }
-    });
+    dispatchSchemeUpdate(scheme);
   }
 </script>
 
@@ -127,7 +139,7 @@
               <ColorSchemePalette
                 colors={scheme[style.count]}
                 active={scheme === style.scheme}
-                onclickscheme={onClickScheme(scheme)}
+                onclickscheme={() => onClickScheme(scheme)}
               />
             {/each}
           {:else}
@@ -135,7 +147,7 @@
               <ColorSchemePalette
                 colors={scheme}
                 active={scheme === style.scheme}
-                onclickscheme={onClickScheme(scheme)}
+                onclickscheme={() => onClickScheme(scheme)}
               />
             {/each}
           {/if}

--- a/src/lib/components/color/ColorStepsSelect.svelte
+++ b/src/lib/components/color/ColorStepsSelect.svelte
@@ -4,6 +4,7 @@
   import Select from '$lib/components/shared/Select.svelte';
   import { dispatchLayerUpdate } from '$lib/interaction/update';
   import type { QuantitativeStyle } from '$lib/types';
+  import { history } from '$lib/state/history.svelte';
 
   interface Props {
     layerId: string;
@@ -20,13 +21,26 @@
   function onColorStepsChange(
     event: Event & { currentTarget: EventTarget & HTMLSelectElement }
   ) {
-    dispatchLayerUpdate({
-      type: 'color-count',
+    const update = {
+      type: 'color-count' as const,
       layerId,
       payload: {
         count: +event.currentTarget.value
       }
+    };
+
+    history.undo.push({
+      execute: update,
+      invert: {
+        type: 'color-count',
+        layerId,
+        payload: {
+          count: style.count
+        }
+      }
     });
+
+    dispatchLayerUpdate(update);
   }
 </script>
 

--- a/src/lib/components/color/ColorVisualizationTypeSelect.svelte
+++ b/src/lib/components/color/ColorVisualizationTypeSelect.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import Select from '$lib/components/shared/Select.svelte';
   import { dispatchLayerUpdate } from '$lib/interaction/update';
+  import { history } from '$lib/state/history.svelte';
   import type { LayerType, VisualizationType } from '$lib/types';
 
   interface Props {
@@ -37,13 +38,26 @@
   function onVisualizationTypeChange(
     event: Event & { currentTarget: EventTarget & HTMLSelectElement }
   ) {
-    dispatchLayerUpdate({
-      type: 'visualization-type',
+    const update = {
+      type: 'visualization-type' as const,
       layerId,
       payload: {
         visualizationType: event.currentTarget.value as VisualizationType
       }
+    };
+
+    history.undo.push({
+      execute: update,
+      invert: {
+        type: 'visualization-type',
+        layerId,
+        payload: {
+          visualizationType
+        }
+      }
     });
+
+    dispatchLayerUpdate(update);
   }
 
   let options = $derived(

--- a/src/lib/components/color/FillModifier.svelte
+++ b/src/lib/components/color/FillModifier.svelte
@@ -2,6 +2,7 @@
   import MinusIcon from '$lib/components/icons/MinusIcon.svelte';
   import PlusIcon from '$lib/components/icons/PlusIcon.svelte';
   import { dispatchLayerUpdate } from '$lib/interaction/update';
+  import { history } from '$lib/state/history.svelte';
   import type {
     CategoricalFill,
     ConstantFill,
@@ -16,19 +17,41 @@
   let { layerId, fill }: Props = $props();
 
   function onRemoveFill() {
-    dispatchLayerUpdate({
-      type: 'remove-fill',
+    const update = {
+      type: 'remove-fill' as const,
       layerId,
       payload: {}
+    };
+
+    history.undo.push({
+      execute: update,
+      invert: {
+        type: 'add-fill',
+        layerId,
+        payload: {}
+      }
     });
+
+    dispatchLayerUpdate(update);
   }
 
   function onAddFill() {
-    dispatchLayerUpdate({
-      type: 'add-fill',
+    const update = {
+      type: 'add-fill' as const,
       layerId,
       payload: {}
+    };
+
+    history.undo.push({
+      execute: update,
+      invert: {
+        type: 'remove-fill',
+        layerId,
+        payload: {}
+      }
     });
+
+    dispatchLayerUpdate(update);
   }
 </script>
 

--- a/src/lib/components/color/FillPicker.svelte
+++ b/src/lib/components/color/FillPicker.svelte
@@ -6,6 +6,7 @@
   import FieldLabel from '$lib/components/shared/FieldLabel.svelte';
   import { dispatchLayerUpdate } from '$lib/interaction/update';
   import type { ConstantFill } from '$lib/types';
+  import { history } from '$lib/state/history.svelte';
   import { DEFAULT_FILL } from '$lib/utils/constants';
 
   interface Props {
@@ -16,13 +17,26 @@
   let { layerId, fill }: Props = $props();
 
   function dispatchFillUpdate(color: string) {
-    dispatchLayerUpdate({
-      type: 'fill',
+    const update = {
+      type: 'fill' as const,
       layerId,
       payload: {
         color
       }
+    };
+
+    history.undo.push({
+      execute: update,
+      invert: {
+        type: 'fill',
+        layerId,
+        payload: {
+          color: fill.color
+        }
+      }
     });
+
+    dispatchLayerUpdate(update);
   }
 
   function onFillInput(

--- a/src/lib/components/color/ManualBreaks.svelte
+++ b/src/lib/components/color/ManualBreaks.svelte
@@ -8,6 +8,7 @@
   import { dispatchLayerUpdate } from '$lib/interaction/update';
   import type { QuantitativeStyle } from '$lib/types';
   import { clickoutside } from '$lib/utils/actions';
+  import { history } from '$lib/state/history.svelte';
 
   interface Props {
     layerId: string;
@@ -23,14 +24,28 @@
 
   function onThresholdChange(i: number) {
     return function handleThresholdChange(value: number) {
-      dispatchLayerUpdate({
-        type: 'color-threshold',
+      const update = {
+        type: 'color-threshold' as const,
         layerId,
         payload: {
           index: i,
           threshold: value
         }
+      };
+
+      history.undo.push({
+        execute: update,
+        invert: {
+          type: 'color-threshold',
+          layerId,
+          payload: {
+            index: i,
+            threshold: style.thresholds[i]
+          }
+        }
       });
+
+      dispatchLayerUpdate(update);
     };
   }
 </script>

--- a/src/lib/components/color/OpacityInput.svelte
+++ b/src/lib/components/color/OpacityInput.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import FieldLabel from '$lib/components/shared/FieldLabel.svelte';
   import { dispatchLayerUpdate } from '$lib/interaction/update';
+  import { history } from '$lib/state/history.svelte';
   import type {
     CategoricalStyle,
     Channel,
@@ -34,11 +35,22 @@
   }
 
   function onOpacityChange(opacity: number) {
-    dispatchLayerUpdate({
-      type: `${channel}-opacity`,
+    const update = {
+      type: `${channel}-opacity` as const,
       layerId,
       payload: { opacity }
+    };
+
+    history.undo.push({
+      execute: update,
+      invert: {
+        type: `${channel}-opacity`,
+        layerId,
+        payload: { opacity: style.opacity }
+      }
     });
+
+    dispatchLayerUpdate(update);
   }
 </script>
 

--- a/src/lib/components/color/StrokeModifier.svelte
+++ b/src/lib/components/color/StrokeModifier.svelte
@@ -2,6 +2,7 @@
   import MinusIcon from '$lib/components/icons/MinusIcon.svelte';
   import PlusIcon from '$lib/components/icons/PlusIcon.svelte';
   import { dispatchLayerUpdate } from '$lib/interaction/update';
+  import { history } from '$lib/state/history.svelte';
   import type { ConstantStroke } from '$lib/types';
 
   interface Props {
@@ -12,19 +13,41 @@
   let { layerId, stroke }: Props = $props();
 
   function onRemoveStroke() {
-    dispatchLayerUpdate({
-      type: 'remove-stroke',
+    const update = {
+      type: 'remove-stroke' as const,
       layerId,
       payload: {}
+    };
+
+    history.undo.push({
+      execute: update,
+      invert: {
+        type: 'add-stroke',
+        layerId,
+        payload: {}
+      }
     });
+
+    dispatchLayerUpdate(update);
   }
 
   function onAddStroke() {
-    dispatchLayerUpdate({
-      type: 'add-stroke',
+    const update = {
+      type: 'add-stroke' as const,
       layerId,
       payload: {}
+    };
+
+    history.undo.push({
+      execute: update,
+      invert: {
+        type: 'remove-stroke',
+        layerId,
+        payload: {}
+      }
     });
+
+    dispatchLayerUpdate(update);
   }
 </script>
 

--- a/src/lib/components/color/StrokePicker.svelte
+++ b/src/lib/components/color/StrokePicker.svelte
@@ -8,6 +8,7 @@
   import { dispatchLayerUpdate } from '$lib/interaction/update';
   import type { ConstantStroke } from '$lib/types';
   import { DEFAULT_STROKE } from '$lib/utils/constants';
+  import { history } from '$lib/state/history.svelte';
 
   interface Props {
     layerId: string;
@@ -16,36 +17,60 @@
 
   let { layerId, stroke }: Props = $props();
 
+  function dispatchStrokeUpdate(color: string) {
+    const update = {
+      type: 'stroke' as const,
+      layerId,
+      payload: {
+        color
+      }
+    };
+
+    history.undo.push({
+      execute: update,
+      invert: {
+        type: 'stroke',
+        layerId,
+        payload: {
+          color: stroke.color
+        }
+      }
+    });
+
+    dispatchLayerUpdate(update);
+  }
+
   function onStrokeInput(
     event: Event & { currentTarget: EventTarget & HTMLInputElement }
   ) {
-    dispatchLayerUpdate({
-      type: 'stroke',
-      layerId,
-      payload: {
-        color: event.currentTarget.value
-      }
-    });
+    dispatchStrokeUpdate(event.currentTarget.value);
   }
 
   function onStrokeHexChange(hex: string) {
-    dispatchLayerUpdate({
-      type: 'stroke',
-      layerId,
-      payload: {
-        color: hex
-      }
-    });
+    dispatchStrokeUpdate(hex);
   }
 
   function onStrokeWidthChange(value: number) {
-    dispatchLayerUpdate({
-      type: 'stroke-width',
+    const update = {
+      type: 'stroke-width' as const,
       layerId,
       payload: {
         strokeWidth: value
       }
+    };
+
+    history.undo.push({
+      execute: update,
+      invert: {
+        type: 'stroke-width',
+        layerId,
+        payload: {
+          strokeWidth: stroke.width
+        }
+      }
     });
+
+    dispatchLayerUpdate(update);
   }
 </script>
 

--- a/src/lib/components/data/AttributeSelect.svelte
+++ b/src/lib/components/data/AttributeSelect.svelte
@@ -28,7 +28,7 @@
   let editor: TransformationEditor | undefined = $state();
   let trigger: HTMLButtonElement;
   let left = $state(0);
-  let attributeEditorVisible = $state(false);
+  let transformationEditorVisible = $state(false);
 
   let properties = $derived(
     Object.keys(geojson.features[0]?.properties ?? {}).filter((prop) =>
@@ -72,7 +72,7 @@
   }
 
   function onClickComputedAttribute() {
-    attributeEditorVisible = true;
+    transformationEditorVisible = true;
     const propertiesMenu = document.getElementById('properties');
 
     if (propertiesMenu) {
@@ -81,11 +81,11 @@
   }
 
   function onCloseEditor() {
-    attributeEditorVisible = false;
+    transformationEditorVisible = false;
   }
 
-  function onClickOutsideEditor(event: MouseEvent) {
-    if (!trigger.contains(event.target as Node)) {
+  function onClickOutsideEditor(event: CustomEvent<MouseEvent>) {
+    if (!trigger.contains(event.detail.target as Node)) {
       onCloseEditor();
     }
   }
@@ -113,7 +113,7 @@
     data-testid="open-transformation-editor-button"><GearIcon /></button
   >
 </div>
-{#if attributeEditorVisible}
+{#if transformationEditorVisible}
   <Portal
     class="absolute top-4"
     {target}

--- a/src/lib/components/data/AttributeSelect.svelte
+++ b/src/lib/components/data/AttributeSelect.svelte
@@ -11,6 +11,7 @@
     isPropertyCategorical,
     isPropertyQuantitative
   } from '$lib/utils/property';
+  import { history } from '$lib/state/history.svelte';
 
   interface Props {
     selected: string;
@@ -46,14 +47,28 @@
   function onAttributeChange(
     event: Event & { currentTarget: EventTarget & HTMLSelectElement }
   ) {
-    dispatchLayerUpdate({
-      type: 'attribute',
+    const update = {
+      type: 'attribute' as const,
       layerId,
       payload: {
         attribute: event.currentTarget.value,
         channel
       }
+    };
+
+    history.undo.push({
+      execute: update,
+      invert: {
+        type: 'attribute',
+        layerId,
+        payload: {
+          attribute: selected,
+          channel
+        }
+      }
     });
+
+    dispatchLayerUpdate(update);
   }
 
   function onClickComputedAttribute() {
@@ -69,8 +84,8 @@
     attributeEditorVisible = false;
   }
 
-  function onClickOutsideEditor(event: CustomEvent<MouseEvent>) {
-    if (!trigger.contains(event.detail.target as Node)) {
+  function onClickOutsideEditor(event: MouseEvent) {
+    if (!trigger.contains(event.target as Node)) {
       onCloseEditor();
     }
   }

--- a/src/lib/components/data/TransformationEditor.svelte
+++ b/src/lib/components/data/TransformationEditor.svelte
@@ -16,11 +16,10 @@
   import { selectedFeature } from '$lib/stores/selected-feature';
   import { parseUserDefinedTransformation } from '$lib/utils/parse';
   import { transformationWorker } from '$lib/utils/worker';
-  import type { MouseEventHandler } from 'svelte/elements';
 
   interface Props {
     oncloseeditor: () => void;
-    onclickoutsideeditor: MouseEventHandler<HTMLElement>;
+    onclickoutsideeditor: (event: CustomEvent<MouseEvent>) => void;
     layerId: string;
     geojson: FeatureCollection;
   }

--- a/src/lib/components/dots/DotControls.svelte
+++ b/src/lib/components/dots/DotControls.svelte
@@ -4,6 +4,7 @@
   import FieldLabel from '$lib/components/shared/FieldLabel.svelte';
   import NumberInput from '$lib/components/shared/NumberInput.svelte';
   import { dispatchLayerUpdate } from '$lib/interaction/update';
+  import { history } from '$lib/state/history.svelte';
   import type { CartoKitDotDensityLayer } from '$lib/types';
 
   interface Props {
@@ -13,13 +14,26 @@
   let { layer }: Props = $props();
 
   function onDotValueChange(value: number) {
-    dispatchLayerUpdate({
-      type: 'dot-value',
+    const update = {
+      type: 'dot-value' as const,
       layerId: layer.id,
       payload: {
         value
       }
+    };
+
+    history.undo.push({
+      execute: update,
+      invert: {
+        type: 'dot-value',
+        layerId: layer.id,
+        payload: {
+          value: layer.style.dots.value
+        }
+      }
     });
+
+    dispatchLayerUpdate(update);
   }
 </script>
 

--- a/src/lib/components/layer-types/LayerTypeSelect.svelte
+++ b/src/lib/components/layer-types/LayerTypeSelect.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import Select from '$lib/components/shared/Select.svelte';
   import { dispatchLayerUpdate } from '$lib/interaction/update';
+  import { history } from '$lib/state/history.svelte';
   import type { CartoKitLayer, LayerType } from '$lib/types';
   import { getFeatureCollectionGeometryType } from '$lib/utils/geojson';
   import { geometryToLayerTypes } from '$lib/utils/layer';
@@ -24,11 +25,24 @@
   function onLayerTypeChange(
     event: Event & { currentTarget: EventTarget & HTMLSelectElement }
   ) {
-    dispatchLayerUpdate({
-      type: 'layer-type',
+    const update = {
+      type: 'layer-type' as const,
       layerId: layer.id,
       payload: { layerType: event.currentTarget.value as LayerType }
+    };
+
+    history.undo.push({
+      execute: update,
+      invert: {
+        type: 'layer-type',
+        layerId: layer.id,
+        payload: {
+          layerType: layer.type
+        }
+      }
     });
+
+    dispatchLayerUpdate(update);
   }
 </script>
 

--- a/src/lib/components/point/PointSize.svelte
+++ b/src/lib/components/point/PointSize.svelte
@@ -2,6 +2,7 @@
   import FieldLabel from '$lib/components/shared/FieldLabel.svelte';
   import NumberInput from '$lib/components/shared/NumberInput.svelte';
   import { dispatchLayerUpdate } from '$lib/interaction/update';
+  import { history } from '$lib/state/history.svelte';
 
   interface Props {
     layerId: string;
@@ -13,13 +14,26 @@
   let { layerId, size, label, fieldId }: Props = $props();
 
   function onPointSizeChange(value: number): void {
-    dispatchLayerUpdate({
-      type: 'point-size',
+    const update = {
+      type: 'point-size' as const,
       layerId,
       payload: {
         size: value
       }
+    };
+
+    history.undo.push({
+      execute: update,
+      invert: {
+        type: 'point-size',
+        layerId,
+        payload: {
+          size: size
+        }
+      }
     });
+
+    dispatchLayerUpdate(update);
   }
 </script>
 

--- a/src/lib/components/shared/Menu.svelte
+++ b/src/lib/components/shared/Menu.svelte
@@ -1,14 +1,13 @@
 <script lang="ts">
   import cs from 'classnames';
   import type { Snippet } from 'svelte';
-  import type { MouseEventHandler } from 'svelte/elements';
 
   import { clickoutside } from '$lib/utils/actions';
 
   interface Props {
     class?: string;
     id?: string;
-    onclickoutsidemenu?: MouseEventHandler<HTMLElement>;
+    onclickoutsidemenu?: (event: CustomEvent<MouseEvent>) => void;
     children: Snippet;
   }
 

--- a/src/lib/components/size/SizeControls.svelte
+++ b/src/lib/components/size/SizeControls.svelte
@@ -3,6 +3,7 @@
   import FieldLabel from '$lib/components/shared/FieldLabel.svelte';
   import NumberInput from '$lib/components/shared/NumberInput.svelte';
   import { dispatchLayerUpdate } from '$lib/interaction/update';
+  import { history } from '$lib/state/history.svelte';
   import type { CartoKitProportionalSymbolLayer } from '$lib/types';
 
   interface Props {
@@ -13,13 +14,26 @@
 
   function onSizeChange(field: 'min' | 'max') {
     return function handleSizeChange(value: number) {
-      dispatchLayerUpdate({
-        type: 'size',
+      const update = {
+        type: 'size' as const,
         layerId: layer.id,
         payload: {
           [field]: value
         }
+      };
+
+      history.undo.push({
+        execute: update,
+        invert: {
+          type: 'size',
+          layerId: layer.id,
+          payload: {
+            [field]: layer.style.size[field]
+          }
+        }
       });
+
+      dispatchLayerUpdate(update);
     };
   }
 </script>

--- a/src/lib/interaction/update.ts
+++ b/src/lib/interaction/update.ts
@@ -181,7 +181,7 @@ interface FillVisualizationUpdate extends LayerUpdate {
   };
 }
 
-type DispatchLayerUpdateParams =
+export type DispatchLayerUpdateParams =
   | LayerTypeUpdate
   | AttributeUpdate
   | FillUpdate

--- a/src/lib/state/history.svelte.ts
+++ b/src/lib/state/history.svelte.ts
@@ -1,0 +1,15 @@
+import type { DispatchLayerUpdateParams } from '$lib/interaction/update';
+
+export const history = $state<{
+  undo: {
+    execute: DispatchLayerUpdateParams;
+    invert: DispatchLayerUpdateParams;
+  }[];
+  redo: {
+    execute: DispatchLayerUpdateParams;
+    invert: DispatchLayerUpdateParams;
+  }[];
+}>({
+  undo: [],
+  redo: []
+});

--- a/src/lib/utils/actions.ts
+++ b/src/lib/utils/actions.ts
@@ -1,5 +1,4 @@
 import type { ActionReturn } from 'svelte/action';
-import type { MouseEventHandler } from 'svelte/elements';
 import { on } from 'svelte/events';
 
 /**
@@ -11,7 +10,10 @@ import { on } from 'svelte/events';
  */
 export function clickoutside<T extends HTMLElement>(
   node: T
-): ActionReturn<undefined, { onclickoutside: MouseEventHandler<HTMLElement> }> {
+): ActionReturn<
+  undefined,
+  { onclickoutside: (event: CustomEvent<MouseEvent>) => void }
+> {
   function handle(event: MouseEvent) {
     if (!event.target) {
       return;

--- a/src/lib/utils/history.ts
+++ b/src/lib/utils/history.ts
@@ -1,0 +1,37 @@
+import { on } from 'svelte/events';
+
+import { dispatchLayerUpdate } from '$lib/interaction/update';
+import { history } from '$lib/state/history.svelte';
+
+/**
+ * Initialize our history interface for undo / redo functionality.
+ *
+ * @returns – A function to remove the undo / redo event listener.
+ */
+export function initHistory() {
+  const off = on(document, 'keydown', (event) => {
+    // Redo action.
+    if (
+      (event.ctrlKey || event.metaKey) &&
+      event.shiftKey &&
+      event.key === 'z'
+    ) {
+      const update = history.redo.pop();
+
+      if (update) {
+        history.undo.push(update);
+        dispatchLayerUpdate(update.execute);
+      }
+      // Undo action.
+    } else if ((event.ctrlKey || event.metaKey) && event.key === 'z') {
+      const update = history.undo.pop();
+
+      if (update) {
+        history.redo.push(update);
+        dispatchLayerUpdate(update.invert);
+      }
+    }
+  });
+
+  return off;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -12,12 +12,13 @@
   import DataTable from '$lib/components/shared/DataTable.svelte';
   import Menu from '$lib/components/shared/Menu.svelte';
   import MenuTitle from '$lib/components/shared/MenuTitle.svelte';
+  import Toolbar from '$lib/components/toolbar/Toolbar.svelte';
   import { onFeatureLeave } from '$lib/interaction/select';
   import { ir } from '$lib/stores/ir';
   import { layout } from '$lib/stores/layout';
   import { map as mapStore } from '$lib/stores/map';
   import { selectedLayer } from '$lib/stores/selected-layer';
-  import Toolbar from '$lib/components/toolbar/Toolbar.svelte';
+  import { initHistory } from '$lib/utils/history';
 
   interface Props {
     data: PageData;
@@ -74,8 +75,11 @@
       map?.setProjection({ type: $ir.projection });
     });
 
+    const destroyHistory = initHistory();
+
     return () => {
       map!.remove();
+      destroyHistory();
     };
   });
 


### PR DESCRIPTION
This PR adds an exciting (and long-awaited!) feature to `cartokit`—undo / redo! This is a table stakes feature for a system like `cartokit`, so this is a long-time coming!

https://github.com/user-attachments/assets/a477f482-eade-4ad5-ba5b-eea7938ea145

The implementation itself uses a variant of the [command pattern](https://en.wikipedia.org/wiki/Command_pattern). We use two stacks—an `undo` stack and a `redo` stack—housed under a single `history` state object.

```ts
const history = $state<{
  undo: {
    execute: DispatchLayerUpdateParams;
    invert: DispatchLayerUpdateParams;
  }[];
  redo: {
    execute: DispatchLayerUpdateParams;
    invert: DispatchLayerUpdateParams;
  }[];
}>({
  undo: [],
  redo: []
});
```

Every time we perform a layer update in `cartokit`, we push an object containing an `execute` diff and an `invert` diff to our `undo` stack; diffs represent the payloads sent to our central `dispatchLayerUpdate` function. When a user presses Cmd+z / Ctrl+z, we pop the top of the `undo` stack, execute the `invert` diff, and push the entry to the `redo` stack. When a user presses Cmd+z / Ctrl + z, we pop the top of the `redo` stack, execute the `execute` diff, and push the entry to the `undo` stack. Pretty standard as things go!

One weird quirk of `cartokit` is that some actions (e.g., layer type transitions) make large changes to the IR that rely on "filling in" certain properties with default or random values. For example, transitioning from a Polygon layer to a Choropleth layer back to a Polygon layer will work, but we may lose the original `fill` color of the Polygon layer because the transition uses a call to `randomColor()` to supply the fill. We can handle these cases with a slight bit of refactoring, but that will come along in a separate PR!