### PR TITLE
feat: Migrate to GPT-4.1.

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -118,7 +118,7 @@
       <div class="flex items-center justify-between px-2 pb-2">
         <code
           class="self-start rounded-xs bg-slate-400 px-1 py-0.5 text-xs text-white"
-          >gpt-4o</code
+          >gpt-4.1</code
         >
         <button
           class="flex h-[22px] w-[22px] items-center justify-center rounded-xs border border-white bg-slate-400 text-white disabled:opacity-50"

--- a/src/lib/interaction/channel.ts
+++ b/src/lib/interaction/channel.ts
@@ -208,6 +208,19 @@ function updateDotsChannel(map: Map, layer: CartoKitDotDensityLayer): void {
   );
 
   layer.data.geojson = features;
+  // Update the args of the dot density transformation in this layer.
+  //
+  // Find the transformation call for the dot density transformation.
+  const transformationIndex = layer.data.transformations.findIndex(
+    (t) => t.name === 'generateDotDensityPoints'
+  );
+
+  if (transformationIndex > -1) {
+    layer.data.transformations[transformationIndex].args = [
+      layer.style.dots.attribute,
+      layer.style.dots.value
+    ];
+  }
 
   // Update the source with the new data.
   (map.getSource(layer.id) as GeoJSONSource).setData(features);

--- a/src/routes/llm/+server.ts
+++ b/src/routes/llm/+server.ts
@@ -65,7 +65,7 @@ export const POST = (async ({ request }) => {
 
   try {
     const completion = await openai.chat.completions.parse({
-      model: 'gpt-4o',
+      model: 'gpt-4.1',
       messages: [
         {
           role: 'system',
@@ -350,15 +350,15 @@ function SizeUpdate(layerIds: string[]) {
     type: z.literal('size'),
     layerId: makeLayerIdSchema(layerIds),
     payload: z.object({
-      min: z.optional(z.number()),
-      max: z.optional(z.number())
+      min: z.number().nullable(),
+      max: z.number().nullable()
     })
   });
 }
 
 function DotValueUpdate(layerIds: string[]) {
   return z.object({
-    type: z.literal('dots'),
+    type: z.literal('dot-value'),
     layerId: makeLayerIdSchema(layerIds),
     payload: z.object({
       value: z.number()


### PR DESCRIPTION
This PR migrates `cartokit`'s large language model support to use GPT-4.1.

Doing so revealed a small bug in the schema that we used for constrained decoding, alongside a small handful of bugs in our **Dot Density** update procedures not addressed in #959. 