### PR TITLE
fix: Prevent page views triggered by Playwright tests from counting towards page traffic.

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Run Playwright tests
         run: pnpm exec playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
         env:
-          PLAYWRIGHT_TEST_BASE_URL: ${{ github.event.deployment_status.environment == 'production' && 'https://alpha.cartokit.dev/' || github.event.deployment_status.target_url }}
+          PLAYWRIGHT_TEST_BASE_URL: ${{ github.event.deployment_status.environment == 'production' && 'https://alpha.cartokit.dev/?playwright=1' || github.event.deployment_status.target_url }}
       - name: Upload blob report to GitHub Actions Artifacts
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -11,7 +11,14 @@
 
   let { children }: Props = $props();
 
-  inject();
+  inject({
+    beforeSend: (event) => {
+      if (event.url.includes('playwright')) {
+        return null;
+      }
+      return event;
+    }
+  });
 </script>
 
 <svelte:head>


### PR DESCRIPTION
A quick PR to prevent page views triggered by Playwright tests from counting towards our total page traffic stats. To do this, we inspect `event.url` for the `playwright` query param (or any occurrence of the string "playwright") and return `null` as part of our implementation of the [`beforeSend` callback](https://vercel.com/docs/analytics/package#beforesend).