### PR TITLE
fix: Preserve order of diffs returned by GPT-5.

### DIFF
--- a/src/lib/state/diffs.svelte.ts
+++ b/src/lib/state/diffs.svelte.ts
@@ -1,0 +1,3 @@
+import type { DispatchLayerUpdateParams } from '$lib/interaction/update';
+
+export const diffs = $state<DispatchLayerUpdateParams[]>([]);


### PR DESCRIPTION
This PR fixes a small bug in our diff logging implementation. Previously, because we'd fire off an asynchronous `fetch` call at the end of `dispatchLayerUpdate`—but never `await` it—we could encounter a race condition where application of diffs would occur in an inconsistent order from that defined by the response from GPT-5. To fix this, we need to keep `dispatchLayerUpdate` fully synchronous.

To do this, we refactored our logging infrastructure to use an asynchronous queue. Now, `dispatchLayerUpdate` simply pushes the diff synchronously to the queue. Then, inside an `$effect`, we grab the element at the front of the queue and log it to our MongoDB database, ensuring that all in flight requests have completed before pulling another item off the queue. This is just a quick hacky fix for tomorrow's user study session 😓 