### PR TITLE
fix: Prevent event propagation on editable CodeMirror instances to ensure we don't trigger global keybindings.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  lint:
+  test:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]

--- a/src/lib/components/shared/CodeEditor.svelte
+++ b/src/lib/components/shared/CodeEditor.svelte
@@ -69,8 +69,17 @@
       parent: editor
     });
 
+    function handleKeyDown(event: KeyboardEvent) {
+      event.stopPropagation();
+    }
+
+    // Prevent keydown events from propagating.
+    // This ensures these events won't trigger our global keybindings.
+    view.dom.addEventListener('keydown', handleKeyDown);
+
     return () => {
       view?.destroy();
+      view?.dom.removeEventListener('keydown', handleKeyDown);
     };
   });
 


### PR DESCRIPTION
After introducing global keybindings in #1109, we forgot to ensure that they are not triggered when a user types in the **Transformation Editor**. This PR corrects that by preventing event propagation on the `keydown` event when a user is typing in the editor.