### PR TITLE
feat: Scaffold a second implementation for continuous color scales.

### DIFF
--- a/src/lib/codegen/codegen-paint.ts
+++ b/src/lib/codegen/codegen-paint.ts
@@ -32,7 +32,7 @@ export function codegenFill(layer: CartoKitLayer): string {
       return [
         layer.style.fill.type === 'Constant'
           ? withDefault('circle-color', layer.style.fill.color)
-          : `'circle-color': ${JSON.stringify(deriveColorScale(layer.style.fill))}`,
+          : `'circle-color': ${JSON.stringify(deriveColorScale(layer.style.fill, layer.id))}`,
         withDefault('circle-radius', layer.style.size),
         withDefault(
           'circle-opacity',
@@ -50,7 +50,7 @@ export function codegenFill(layer: CartoKitLayer): string {
       return [
         layer.style.fill.type === 'Constant'
           ? withDefault('circle-color', layer.style.fill.color)
-          : `'circle-color': ${JSON.stringify(deriveColorScale(layer.style.fill))}`,
+          : `'circle-color': ${JSON.stringify(deriveColorScale(layer.style.fill, layer.id))}`,
         `'circle-radius': ${JSON.stringify(deriveSize(layer))}`,
         withDefault(
           'circle-opacity',
@@ -92,7 +92,7 @@ export function codegenFill(layer: CartoKitLayer): string {
     }
     case 'Choropleth': {
       return [
-        `'fill-color': ${JSON.stringify(deriveColorScale(layer.style.fill))}`,
+        `'fill-color': ${JSON.stringify(deriveColorScale(layer.style.fill, layer.id))}`,
         withDefault('fill-opacity', layer.style.fill.opacity)
       ]
         .filter(Boolean)

--- a/src/lib/components/channel/heatmap/HeatmapColor.svelte
+++ b/src/lib/components/channel/heatmap/HeatmapColor.svelte
@@ -9,11 +9,11 @@
   import Portal from '$lib/components/shared/Portal.svelte';
   import type {
     CartoKitHeatmapLayer,
-    ColorRamp as ColorRampType,
+    QuantitativeColorRamp,
     RampDirection
   } from '$lib/types';
 
-  import { COLOR_RAMPS } from '$lib/utils/color/ramp';
+  import { QUANTITATIVE_COLOR_RAMPS } from '$lib/utils/color/ramp';
 
   interface Props {
     layer: CartoKitHeatmapLayer;
@@ -39,7 +39,7 @@
     showOptions = false;
   }
 
-  async function onClickRamp(ramp: ColorRampType) {
+  async function onClickRamp(ramp: QuantitativeColorRamp) {
     const diff: CartoKitDiff = {
       type: 'heatmap-ramp',
       layerId: layer.id,
@@ -94,7 +94,7 @@
         <ul
           class="flex max-h-44 flex-col overflow-auto rounded-md border border-slate-600 bg-slate-900 shadow-lg"
         >
-          {#each COLOR_RAMPS as ramp (ramp)}
+          {#each QUANTITATIVE_COLOR_RAMPS as ramp (ramp)}
             <li>
               <button
                 onclick={() => onClickRamp(ramp)}

--- a/src/lib/components/channel/shared/ColorRamp.svelte
+++ b/src/lib/components/channel/shared/ColorRamp.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
   import { onMount } from 'svelte';
 
-  import type { ColorRamp, RampDirection } from '$lib/types';
+  import type { QuantitativeColorRamp, RampDirection } from '$lib/types';
   import { materializeColorRamp } from '$lib/utils/color/ramp';
 
   interface Props {
-    ramp: ColorRamp;
+    ramp: QuantitativeColorRamp;
     direction: RampDirection;
   }
 

--- a/src/lib/components/color/ColorControls.svelte
+++ b/src/lib/components/color/ColorControls.svelte
@@ -40,7 +40,7 @@
       selected={fill.attribute}
       channel="fill"
     />
-    <ColorSchemeSelect {layerId} style={fill} />
+    <ColorSchemeSelect {layerId} scale={fill.scale} />
   {:else if fill.type === 'Quantitative'}
     <AttributeSelect
       {layerId}
@@ -49,9 +49,17 @@
       selected={fill.attribute}
       channel="fill"
     />
-    <ClassificationMethodSelect {layerId} style={fill} />
-    <StepsSelect {layerId} style={fill} />
-    <ColorSchemeSelect {layerId} style={fill} />
+    <ClassificationMethodSelect
+      {layerId}
+      attribute={fill.attribute}
+      scale={fill.scale}
+    />
+    {#if fill.scale.type === 'Continuous'}
+      <div>TODO</div>
+    {:else}
+      <StepsSelect {layerId} scale={fill.scale} />
+      <ColorSchemeSelect {layerId} scale={fill.scale} />
+    {/if}
   {/if}
   <OpacityInput {layerId} channel="fill" style={fill} />
 </div>

--- a/src/lib/components/color/ColorControls.svelte
+++ b/src/lib/components/color/ColorControls.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { FeatureCollection } from 'geojson';
 
+  import ColorRampSelect from '$lib/components/color/ColorRampSelect.svelte';
   import ColorSchemeSelect from '$lib/components/color/ColorSchemeSelect.svelte';
   import FillPicker from '$lib/components/color/FillPicker.svelte';
   import OpacityInput from '$lib/components/color/OpacityInput.svelte';
@@ -55,7 +56,11 @@
       scale={fill.scale}
     />
     {#if fill.scale.type === 'Continuous'}
-      <div>TODO</div>
+      <ColorRampSelect
+        {layerId}
+        channel="fill-color"
+        ramp={fill.scale.interpolator}
+      />
     {:else}
       <StepsSelect {layerId} scale={fill.scale} />
       <ColorSchemeSelect {layerId} scale={fill.scale} />

--- a/src/lib/components/color/ColorRampSelect.svelte
+++ b/src/lib/components/color/ColorRampSelect.svelte
@@ -72,14 +72,14 @@
   <FieldLabel fieldId="{channel}-ramp">Ramp</FieldLabel>
   <div
     id="{channel}-ramp"
-    class="flex grow items-center border border-transparent p-2 focus-within:border-slate-600 hover:border-slate-600"
+    class="flex grow items-center"
     bind:this={trigger}
     bind:offsetHeight
     bind:offsetWidth
   >
     <button
       onclick={onClickCurrentRamp}
-      class="flex-1"
+      class="flex-1 border border-transparent p-2 focus-within:border-slate-600 hover:border-slate-600"
       {@attach onClickOutside({ callback: onClickOutsideCurrentRamp })}
     >
       <ColorRamp ramp={ramp.id} direction={ramp.direction} />
@@ -95,14 +95,14 @@
         <ul
           class="flex max-h-44 flex-col overflow-auto rounded-md border border-slate-600 bg-slate-900 shadow-lg"
         >
-          {#each QUANTITATIVE_COLOR_RAMPS as rampOption (rampOption)}
+          {#each QUANTITATIVE_COLOR_RAMPS as colramp (colramp)}
             <li>
               <button
-                onclick={() => onClickRamp(rampOption)}
-                use:focus={() => rampOption === ramp.id}
+                onclick={() => onClickRamp(colramp)}
+                use:focus={() => colramp === ramp.id}
                 class="w-full p-2 hover:bg-slate-700"
               >
-                <ColorRamp ramp={rampOption} direction={ramp.direction} />
+                <ColorRamp ramp={colramp} direction={ramp.direction} />
               </button>
             </li>
           {/each}

--- a/src/lib/components/color/ColorRampSelect.svelte
+++ b/src/lib/components/color/ColorRampSelect.svelte
@@ -5,21 +5,18 @@
   import ColorRamp from '$lib/components/channel/shared/ColorRamp.svelte';
   import ReverseIcon from '$lib/components/icons/ReverseIcon.svelte';
   import FieldLabel from '$lib/components/shared/FieldLabel.svelte';
-  import { applyDiff, type CartoKitDiff } from '$lib/core/diff';
   import Portal from '$lib/components/shared/Portal.svelte';
-  import type {
-    CartoKitHeatmapLayer,
-    QuantitativeColorRamp,
-    RampDirection
-  } from '$lib/types';
-
+  import { applyDiff, type CartoKitDiff } from '$lib/core/diff';
+  import type { QuantitativeColorRamp, RampDirection } from '$lib/types';
   import { QUANTITATIVE_COLOR_RAMPS } from '$lib/utils/color/ramp';
 
   interface Props {
-    layer: CartoKitHeatmapLayer;
+    layerId: string;
+    channel: 'heatmap-color' | 'fill-color';
+    ramp: { id: QuantitativeColorRamp; direction: RampDirection };
   }
 
-  let { layer }: Props = $props();
+  let { layerId, channel, ramp }: Props = $props();
 
   const target = document.getElementById('map') ?? document.body;
   let trigger: HTMLDivElement;
@@ -39,72 +36,71 @@
     showOptions = false;
   }
 
-  async function onClickRamp(ramp: QuantitativeColorRamp) {
-    const diff: CartoKitDiff = {
-      type: 'heatmap-ramp',
-      layerId: layer.id,
-      payload: { ramp }
-    };
+  async function onClickRamp(id: QuantitativeColorRamp) {
+    showOptions = false;
+
+    const diff: CartoKitDiff =
+      channel === 'heatmap-color'
+        ? { type: 'heatmap-ramp', layerId, payload: { ramp: id } }
+        : { type: 'fill-color-ramp', layerId, payload: { ramp: id } };
 
     await applyDiff(diff);
   }
 
   async function onRampReverse() {
-    const currentDirection = layer.style.heatmap.ramp.direction;
     const nextDirection: RampDirection =
-      currentDirection === 'Forward' ? 'Reverse' : 'Forward';
+      ramp.direction === 'Forward' ? 'Reverse' : 'Forward';
 
-    const diff: CartoKitDiff = {
-      type: 'heatmap-ramp-direction',
-      layerId: layer.id,
-      payload: { direction: nextDirection }
-    };
+    const diff: CartoKitDiff =
+      channel === 'heatmap-color'
+        ? {
+            type: 'heatmap-ramp-direction',
+            layerId,
+            payload: { direction: nextDirection }
+          }
+        : {
+            type: 'fill-color-ramp-direction',
+            layerId,
+            payload: { direction: nextDirection }
+          };
 
     await applyDiff(diff);
   }
 </script>
 
 <div class="flex items-center gap-2">
-  <FieldLabel fieldId="heatmap-color-ramp">Ramp</FieldLabel>
+  <FieldLabel fieldId="{channel}-ramp">Ramp</FieldLabel>
   <div
-    id="heatmap-color-ramp"
-    class="flex grow items-center"
+    id="{channel}-ramp"
+    class="flex grow items-center border border-transparent p-2 focus-within:border-slate-600 hover:border-slate-600"
     bind:this={trigger}
     bind:offsetHeight
     bind:offsetWidth
   >
     <button
       onclick={onClickCurrentRamp}
-      class="flex-1 border border-transparent p-2 focus-within:border-slate-600 hover:border-slate-600"
+      class="flex-1"
       {@attach onClickOutside({ callback: onClickOutsideCurrentRamp })}
     >
-      <ColorRamp
-        ramp={layer.style.heatmap.ramp.id}
-        direction={layer.style.heatmap.ramp.direction}
-      />
+      <ColorRamp ramp={ramp.id} direction={ramp.direction} />
     </button>
     {#if showOptions}
       <Portal
         {target}
         class="absolute z-10"
-        style="top: {offsetHeight +
-          y +
-          4}px; left: {x}px; width: {offsetWidth}px;"
+        style="top: {offsetHeight + y + 4}px; left: {x}px; width: {offsetWidth}px;"
       >
         <ul
           class="flex max-h-44 flex-col overflow-auto rounded-md border border-slate-600 bg-slate-900 shadow-lg"
         >
-          {#each QUANTITATIVE_COLOR_RAMPS as ramp (ramp)}
+          {#each QUANTITATIVE_COLOR_RAMPS as rampOption (rampOption)}
             <li>
               <button
-                onclick={() => onClickRamp(ramp)}
-                use:focus={() => ramp === layer.style.heatmap.ramp.id}
-                class="flex-1 p-2 hover:bg-slate-700"
+                onclick={() => onClickRamp(rampOption)}
+                use:focus={() => rampOption === ramp.id}
+                class="w-full p-2 hover:bg-slate-700"
               >
-                <ColorRamp
-                  {ramp}
-                  direction={layer.style.heatmap.ramp.direction}
-                />
+                <ColorRamp ramp={rampOption} direction={ramp.direction} />
               </button>
             </li>
           {/each}
@@ -114,9 +110,7 @@
   </div>
   <button
     onclick={onRampReverse}
-    data-testid="color-ramp-reverse-button"
-    {@attach tooltip({
-      content: 'Reverse Ramp'
-    })}><ReverseIcon /></button
-  >
+    data-testid="{channel}-ramp-reverse-button"
+    {@attach tooltip({ content: 'Reverse Ramp' })}
+  ><ReverseIcon /></button>
 </div>

--- a/src/lib/components/color/ColorRampSelect.svelte
+++ b/src/lib/components/color/ColorRampSelect.svelte
@@ -88,7 +88,9 @@
       <Portal
         {target}
         class="absolute z-10"
-        style="top: {offsetHeight + y + 4}px; left: {x}px; width: {offsetWidth}px;"
+        style="top: {offsetHeight +
+          y +
+          4}px; left: {x}px; width: {offsetWidth}px;"
       >
         <ul
           class="flex max-h-44 flex-col overflow-auto rounded-md border border-slate-600 bg-slate-900 shadow-lg"
@@ -111,6 +113,6 @@
   <button
     onclick={onRampReverse}
     data-testid="{channel}-ramp-reverse-button"
-    {@attach tooltip({ content: 'Reverse Ramp' })}
-  ><ReverseIcon /></button>
+    {@attach tooltip({ content: 'Reverse Ramp' })}><ReverseIcon /></button
+  >
 </div>

--- a/src/lib/components/color/ColorSchemeSelect.svelte
+++ b/src/lib/components/color/ColorSchemeSelect.svelte
@@ -8,10 +8,11 @@
   import Portal from '$lib/components/shared/Portal.svelte';
   import { applyDiff, type CartoKitDiff } from '$lib/core/diff';
   import type {
+    CategoricalColorScale,
     CategoricalColorScheme,
+    ContinuousColorScale,
+    QuantitativeColorScale,
     QuantitativeColorScheme,
-    QuantitativeStyle,
-    CategoricalStyle,
     SchemeDirection
   } from '$lib/types';
   import {
@@ -21,10 +22,12 @@
 
   interface Props {
     layerId: string;
-    style: QuantitativeStyle | CategoricalStyle;
+    scale:
+      | Exclude<QuantitativeColorScale, ContinuousColorScale>
+      | CategoricalColorScale;
   }
 
-  let { layerId, style }: Props = $props();
+  let { layerId, scale }: Props = $props();
 
   let showOptions = $state(false);
   let offsetHeight = $state(0);
@@ -33,9 +36,9 @@
   let y = $state(0);
 
   let schemes = $derived(
-    style.type === 'Quantitative'
-      ? QUANTITATIVE_COLOR_SCHEMES
-      : CATEGORICAL_COLOR_SCHEMES
+    scale.type === 'Categorical'
+      ? CATEGORICAL_COLOR_SCHEMES
+      : QUANTITATIVE_COLOR_SCHEMES
   );
 
   let trigger: HTMLDivElement;
@@ -67,7 +70,7 @@
   }
 
   async function onSchemeReverse() {
-    const currentDirection = style.scheme.direction;
+    const currentDirection = scale.scheme.direction;
     const nextDirection: SchemeDirection =
       currentDirection === 'Forward' ? 'Reverse' : 'Forward';
 
@@ -98,9 +101,9 @@
       {@attach onClickOutside({ callback: onClickOutsideCurrentScheme })}
     >
       <ColorPalette
-        scheme={style.scheme.id}
-        direction={style.scheme.direction}
-        count={style.type === 'Quantitative' ? style.count : undefined}
+        scheme={scale.scheme.id}
+        direction={scale.scheme.direction}
+        count={scale.type === 'Categorical' ? undefined : scale.steps}
       />
     </button>
     {#if showOptions}
@@ -118,15 +121,13 @@
             <li class="flex">
               <button
                 onclick={() => onClickScheme(scheme)}
-                use:focus={() => scheme === style.scheme.id}
+                use:focus={() => scheme === scale.scheme.id}
                 class="flex-1 p-2 hover:bg-slate-700"
               >
                 <ColorPalette
                   {scheme}
-                  direction={style.scheme.direction}
-                  count={style.type === 'Quantitative'
-                    ? style.count
-                    : undefined}
+                  direction={scale.scheme.direction}
+                  count={scale.type === 'Categorical' ? undefined : scale.steps}
                 />
               </button>
             </li>

--- a/src/lib/components/legends/CategoricalLegend.svelte
+++ b/src/lib/components/legends/CategoricalLegend.svelte
@@ -15,14 +15,16 @@
   let { fill, stroke, layerType, visible }: Props = $props();
 
   let entries = $derived(
-    d3[fill.scheme.id].length < fill.categories.length
-      ? fill.categories.slice(0, d3[fill.scheme.id].length).concat('Other')
-      : fill.categories
+    d3[fill.scale.scheme.id].length < fill.scale.categories.length
+      ? fill.scale.categories
+          .slice(0, d3[fill.scale.scheme.id].length)
+          .concat('Other')
+      : fill.scale.categories
   );
   let colors = $derived(
     materializeColorScheme(
-      fill.scheme.id,
-      fill.scheme.direction,
+      fill.scale.scheme.id,
+      fill.scale.scheme.direction,
       entries.length
     )
   );

--- a/src/lib/components/legends/CategoricalLegend.svelte
+++ b/src/lib/components/legends/CategoricalLegend.svelte
@@ -2,7 +2,6 @@
   import * as d3 from 'd3';
 
   import type { CategoricalFill, ConstantStroke, LayerType } from '$lib/types';
-  import { DEFAULT_FILL } from '$lib/utils/constants';
   import { materializeColorScheme } from '$lib/utils/color/scheme';
 
   interface Props {
@@ -42,7 +41,7 @@
               y="0"
               width="32"
               height="16"
-              fill={colors[i] ?? DEFAULT_FILL}
+              fill={colors[i]}
               fill-opacity={fill.opacity}
               stroke={stroke.visible ? stroke.color : 'none'}
               stroke-width={stroke.visible ? stroke.width : 0}
@@ -55,7 +54,7 @@
               r="7"
               cx="8"
               cy="8"
-              fill={colors[i] ?? DEFAULT_FILL}
+              fill={colors[i]}
               fill-opacity={fill.opacity}
               stroke={stroke.visible ? stroke.color : 'none'}
               stroke-width={stroke.visible ? stroke.width : 0}

--- a/src/lib/components/legends/ChoroplethLegend.svelte
+++ b/src/lib/components/legends/ChoroplethLegend.svelte
@@ -10,7 +10,7 @@
   let { layer }: Props = $props();
 </script>
 
-<div class="ml-8 flex flex-col gap-2">
+<div class="ml-8 flex flex-col gap-2" data-testid="choropleth-legend">
   {#if layer.style.fill.visible && layer.style.fill.type === 'Categorical'}
     <CategoricalLegend
       fill={layer.style.fill}

--- a/src/lib/components/legends/HeatmapLegend.svelte
+++ b/src/lib/components/legends/HeatmapLegend.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import ColorSchemeRamp from '$lib/components/channel/shared/ColorRamp.svelte';
+  import ColorRamp from '$lib/components/channel/shared/ColorRamp.svelte';
   import type { CartoKitHeatmapLayer } from '$lib/types';
 
   interface Props {
@@ -11,7 +11,7 @@
 
 <div
   class={[
-    'ml-8 flex max-w-48 flex-col gap-2',
+    'ml-8 flex flex-col gap-2',
     layer.layout.visible ? 'opacity-100' : 'opacity-75'
   ]}
 >
@@ -20,11 +20,11 @@
       >{layer.style.heatmap.weight.attribute} →</span
     >
   {/if}
-  <ColorSchemeRamp
+  <ColorRamp
     ramp={layer.style.heatmap.ramp.id}
     direction={layer.style.heatmap.ramp.direction}
   />
-  <div class="text-2xs flex justify-between">
+  <div class="text-3xs flex justify-between">
     <span>Low</span>
     <span>High</span>
   </div>

--- a/src/lib/components/legends/QuantitativeLegend.svelte
+++ b/src/lib/components/legends/QuantitativeLegend.svelte
@@ -2,6 +2,7 @@
   import type { ConstantStroke, LayerType, QuantitativeFill } from '$lib/types';
   import { catalog } from '$lib/state/catalog.svelte';
   import { materializeColorScheme } from '$lib/utils/color/scheme';
+  import ColorRamp from '$lib/components/channel/shared/ColorRamp.svelte';
 
   interface Props {
     fill: QuantitativeFill;
@@ -26,7 +27,19 @@
 </script>
 
 {#if fill.scale.type === 'Continuous'}
-  <div>TODO</div>
+  <div class={['flex flex-col gap-2', visible ? 'opacity-100' : 'opacity-75']}>
+    <p class="font-semibold">{fill.attribute} ↓</p>
+    <div class="flex flex-col gap-1">
+      <ColorRamp
+        ramp={fill.scale.interpolator.id}
+        direction={fill.scale.interpolator.direction}
+      />
+      <div class="flex justify-between font-mono text-xs">
+        <span>{min.toFixed(2)}</span>
+        <span>{max.toFixed(2)}</span>
+      </div>
+    </div>
+  </div>
 {:else}
   <div class={['flex flex-col gap-2', visible ? 'opacity-100' : 'opacity-75']}>
     <p class="font-semibold">{fill.attribute} ↓</p>

--- a/src/lib/components/legends/QuantitativeLegend.svelte
+++ b/src/lib/components/legends/QuantitativeLegend.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-  import type { ConstantStroke, LayerType, QuantitativeFill } from '$lib/types';
-  import { catalog } from '$lib/state/catalog.svelte';
-  import { materializeColorScheme } from '$lib/utils/color/scheme';
   import ColorRamp from '$lib/components/channel/shared/ColorRamp.svelte';
+  import { catalog } from '$lib/state/catalog.svelte';
+  import type { ConstantStroke, LayerType, QuantitativeFill } from '$lib/types';
+  import { materializeColorScheme } from '$lib/utils/color/scheme';
 
   interface Props {
     fill: QuantitativeFill;
@@ -28,13 +28,13 @@
 
 {#if fill.scale.type === 'Continuous'}
   <div class={['flex flex-col gap-2', visible ? 'opacity-100' : 'opacity-75']}>
-    <p class="font-semibold">{fill.attribute} ↓</p>
-    <div class="flex flex-col gap-1">
+    <p class="font-semibold">{fill.attribute} →</p>
+    <div class="flex flex-col gap-2">
       <ColorRamp
         ramp={fill.scale.interpolator.id}
         direction={fill.scale.interpolator.direction}
       />
-      <div class="flex justify-between font-mono text-xs">
+      <div class="text-3xs flex justify-between font-mono">
         <span>{min.toFixed(2)}</span>
         <span>{max.toFixed(2)}</span>
       </div>

--- a/src/lib/components/legends/QuantitativeLegend.svelte
+++ b/src/lib/components/legends/QuantitativeLegend.svelte
@@ -15,54 +15,64 @@
   let { min, max } = $derived(catalog.value[layerId][fill.attribute]);
 
   let colors = $derived(
-    materializeColorScheme(fill.scheme.id, fill.scheme.direction, fill.count)
+    fill.scale.type === 'Continuous'
+      ? []
+      : materializeColorScheme(
+          fill.scale.scheme.id,
+          fill.scale.scheme.direction,
+          fill.scale.steps
+        )
   );
 </script>
 
-<div class={['flex flex-col gap-2', visible ? 'opacity-100' : 'opacity-75']}>
-  <p class="font-semibold">{fill.attribute} ↓</p>
-  <div class="flex gap-2 rounded-md bg-slate-900">
-    <ul class="mt-3 flex flex-col gap-2">
-      {#each colors as color (color)}
-        <li>
-          {#if layerType === 'Choropleth'}
-            <svg viewBox="0 0 32 16" width="32" height="16">
-              <rect
-                x="0"
-                y="0"
-                width="32"
-                height="16"
-                fill={color}
-                fill-opacity={fill.opacity}
-                stroke={stroke.visible ? stroke.color : 'none'}
-                stroke-width={stroke.visible ? stroke.width : 0}
-                stroke-opacity={stroke.visible ? stroke.opacity : 0}
-              />
-            </svg>
-          {:else if layerType === 'Proportional Symbol' || layerType === 'Point'}
-            <svg viewBox="0 0 16 16" width="16" height="16">
-              <circle
-                r="7"
-                cx="8"
-                cy="8"
-                fill={color}
-                fill-opacity={fill.opacity}
-                stroke={stroke.visible ? stroke.color : 'none'}
-                stroke-width={stroke.visible ? stroke.width : 0}
-                stroke-opacity={stroke.visible ? stroke.opacity : 0}
-              />
-            </svg>
-          {/if}
-        </li>
-      {/each}
-    </ul>
-    <ul class="flex flex-col gap-2">
-      {#each [min, ...fill.thresholds, max] as stop (stop)}
-        <li class="text-3xs flex h-4 gap-2 font-mono">
-          <span class="text-slate-400"> → </span>
-          <span>{stop.toFixed(2)}</span>
-        </li>
-      {/each}
-    </ul>
+{#if fill.scale.type === 'Continuous'}
+  <div>TODO</div>
+{:else}
+  <div class={['flex flex-col gap-2', visible ? 'opacity-100' : 'opacity-75']}>
+    <p class="font-semibold">{fill.attribute} ↓</p>
+    <div class="flex gap-2 rounded-md bg-slate-900">
+      <ul class="mt-3 flex flex-col gap-2">
+        {#each colors as color (color)}
+          <li>
+            {#if layerType === 'Choropleth'}
+              <svg viewBox="0 0 32 16" width="32" height="16">
+                <rect
+                  x="0"
+                  y="0"
+                  width="32"
+                  height="16"
+                  fill={color}
+                  fill-opacity={fill.opacity}
+                  stroke={stroke.visible ? stroke.color : 'none'}
+                  stroke-width={stroke.visible ? stroke.width : 0}
+                  stroke-opacity={stroke.visible ? stroke.opacity : 0}
+                />
+              </svg>
+            {:else if layerType === 'Proportional Symbol' || layerType === 'Point'}
+              <svg viewBox="0 0 16 16" width="16" height="16">
+                <circle
+                  r="7"
+                  cx="8"
+                  cy="8"
+                  fill={color}
+                  fill-opacity={fill.opacity}
+                  stroke={stroke.visible ? stroke.color : 'none'}
+                  stroke-width={stroke.visible ? stroke.width : 0}
+                  stroke-opacity={stroke.visible ? stroke.opacity : 0}
+                />
+              </svg>
+            {/if}
+          </li>
+        {/each}
+      </ul>
+      <ul class="flex flex-col gap-2">
+        {#each [min, ...fill.scale.thresholds, max] as stop (stop)}
+          <li class="text-3xs flex h-4 gap-2 font-mono">
+            <span class="text-slate-400"> → </span>
+            <span>{stop.toFixed(2)}</span>
+          </li>
+        {/each}
+      </ul>
+    </div>
   </div>
-</div>
+{/if}

--- a/src/lib/components/properties/HeatmapPropertiesPanel.svelte
+++ b/src/lib/components/properties/HeatmapPropertiesPanel.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-  import ColorRampSelect from '$lib/components/color/ColorRampSelect.svelte';
   import HeatmapOpacity from '$lib/components/channel/heatmap/HeatmapOpacity.svelte';
   import HeatmapRadius from '$lib/components/channel/heatmap/HeatmapRadius.svelte';
   import HeatmapWeight from '$lib/components/channel/heatmap/HeatmapWeight.svelte';
+  import ColorRampSelect from '$lib/components/color/ColorRampSelect.svelte';
   import MenuItem from '$lib/components/shared/MenuItem.svelte';
   import type { CartoKitHeatmapLayer } from '$lib/types';
 

--- a/src/lib/components/properties/HeatmapPropertiesPanel.svelte
+++ b/src/lib/components/properties/HeatmapPropertiesPanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import HeatmapColor from '$lib/components/channel/heatmap/HeatmapColor.svelte';
+  import ColorRampSelect from '$lib/components/color/ColorRampSelect.svelte';
   import HeatmapOpacity from '$lib/components/channel/heatmap/HeatmapOpacity.svelte';
   import HeatmapRadius from '$lib/components/channel/heatmap/HeatmapRadius.svelte';
   import HeatmapWeight from '$lib/components/channel/heatmap/HeatmapWeight.svelte';
@@ -17,7 +17,11 @@
   <HeatmapWeight {layer} />
 </MenuItem>
 <MenuItem title="Display">
-  <HeatmapColor {layer} />
+  <ColorRampSelect
+    layerId={layer.id}
+    channel="heatmap-color"
+    ramp={layer.style.heatmap.ramp}
+  />
   <HeatmapRadius {layer} />
   <HeatmapOpacity {layer} />
 </MenuItem>

--- a/src/lib/components/scale/ClassificationMethodSelect.svelte
+++ b/src/lib/components/scale/ClassificationMethodSelect.svelte
@@ -5,22 +5,23 @@
   import Portal from '$lib/components/shared/Portal.svelte';
   import Select from '$lib/components/shared/Select.svelte';
   import { applyDiff, type CartoKitDiff } from '$lib/core/diff';
-  import type { ClassificationMethod, QuantitativeStyle } from '$lib/types';
-  import { CLASSIFICATION_METHODS } from '$lib/utils/classification';
   import { layout } from '$lib/stores/layout';
+  import type { QuantitativeColorScale } from '$lib/types';
+  import { CLASSIFICATION_METHODS } from '$lib/utils/classification';
 
   interface Props {
     layerId: string;
-    style: QuantitativeStyle;
+    attribute: string;
+    scale: QuantitativeColorScale;
   }
 
-  let { layerId, style }: Props = $props();
+  let { layerId, attribute, scale }: Props = $props();
 
   let displayBreaksEditor = $state(false);
 
-  const options = CLASSIFICATION_METHODS.map((scale) => ({
-    value: scale,
-    label: scale
+  const options = CLASSIFICATION_METHODS.map((option) => ({
+    value: option,
+    label: option
   }));
 
   function showBreaksEditor() {
@@ -44,7 +45,7 @@
       type: 'fill-classification-method',
       layerId,
       payload: {
-        method: event.currentTarget.value as ClassificationMethod
+        method: event.currentTarget.value as QuantitativeColorScale['type']
       }
     };
 
@@ -55,30 +56,30 @@
 <div class="flex items-center gap-2">
   <Select
     {options}
-    selected={style.method}
+    selected={scale.type}
     title="Method"
     id="fill-classification-method-select"
     onchange={onClassificationMethodChange}
   />
-  {#if style.method === 'Manual'}
+  {#if scale.type === 'Manual'}
     <button onclick={showBreaksEditor}>
       <MoreIcon />
     </button>
+    <Portal
+      class={[
+        'ease-cubic-out fixed top-64 right-150 transition-transform duration-400',
+        {
+          '-translate-x-[33.333333vw]': $layout.editorVisible,
+          'delay-150': !$layout.editorVisible
+        }
+      ]}
+    >
+      <Dialog bind:showDialog={displayBreaksEditor} class="w-64">
+        {#snippet header()}
+          <p class="font-sans text-sm font-medium tracking-wider">Set steps</p>
+        {/snippet}
+        <StepsEditor {layerId} {attribute} {scale} />
+      </Dialog>
+    </Portal>
   {/if}
 </div>
-<Portal
-  class={[
-    'ease-cubic-out fixed top-64 right-150 transition-transform duration-400',
-    {
-      '-translate-x-[33.333333vw]': $layout.editorVisible,
-      'delay-150': !$layout.editorVisible
-    }
-  ]}
->
-  <Dialog bind:showDialog={displayBreaksEditor} class="w-64">
-    {#snippet header()}
-      <p class="font-sans text-sm font-medium tracking-wider">Set steps</p>
-    {/snippet}
-    <StepsEditor {layerId} {style} />
-  </Dialog>
-</Portal>

--- a/src/lib/components/scale/StepCountSelect.svelte
+++ b/src/lib/components/scale/StepCountSelect.svelte
@@ -3,14 +3,17 @@
 
   import Select from '$lib/components/shared/Select.svelte';
   import { applyDiff, type CartoKitDiff } from '$lib/core/diff';
-  import type { QuantitativeStyle } from '$lib/types';
+  import type {
+    QuantitativeColorScale,
+    ContinuousColorScale
+  } from '$lib/types';
 
   interface Props {
     layerId: string;
-    style: QuantitativeStyle;
+    scale: Exclude<QuantitativeColorScale, ContinuousColorScale>;
   }
 
-  let { layerId, style }: Props = $props();
+  let { layerId, scale }: Props = $props();
 
   const options = d3.range(3, 10).map((_, i) => ({
     value: i + 3,
@@ -34,7 +37,7 @@
 
 <Select
   {options}
-  selected={style.count}
+  selected={scale.steps}
   title="Steps"
   id="fill-step-count-select"
   onchange={onStepCountChange}

--- a/src/lib/components/scale/StepsEditor.svelte
+++ b/src/lib/components/scale/StepsEditor.svelte
@@ -1,19 +1,23 @@
 <script lang="ts">
   import NumberInput from '$lib/components/shared/NumberInput.svelte';
   import { applyDiff, type CartoKitDiff } from '$lib/core/diff';
-  import type { QuantitativeStyle } from '$lib/types';
   import { catalog } from '$lib/state/catalog.svelte';
+  import type {
+    ContinuousColorScale,
+    QuantitativeColorScale
+  } from '$lib/types';
   import { materializeColorScheme } from '$lib/utils/color/scheme';
 
   interface Props {
     layerId: string;
-    style: QuantitativeStyle;
+    attribute: string;
+    scale: Exclude<QuantitativeColorScale, ContinuousColorScale>;
   }
 
-  let { layerId, style }: Props = $props();
-  let { min, max } = $derived(catalog.value[layerId][style.attribute]);
+  let { layerId, attribute, scale }: Props = $props();
+  let { min, max } = $derived(catalog.value[layerId][attribute]);
   let colors = $derived(
-    materializeColorScheme(style.scheme.id, style.scheme.direction, style.count)
+    materializeColorScheme(scale.scheme.id, scale.scheme.direction, scale.steps)
   );
 
   function onThresholdChange(i: number) {
@@ -33,7 +37,7 @@
 </script>
 
 <div data-testid="breaks-editor" class="font-mono text-xs">
-  {#each [min, ...style.thresholds] as threshold, i (threshold)}
+  {#each [min, ...scale.thresholds] as threshold, i (threshold)}
     <div
       class="grid grid-cols-[3rem_minmax(0,1fr)_minmax(0,1fr)] gap-x-1 gap-y-2 border-b border-slate-600 last:border-b-0"
     >
@@ -46,7 +50,7 @@
       <NumberInput
         {min}
         {max}
-        value={style.thresholds[i - 1] ?? min}
+        value={scale.thresholds[i - 1] ?? min}
         step={0.01}
         class="self-center hover:border-transparent"
         disabled={i === 0}
@@ -55,10 +59,10 @@
       <NumberInput
         {min}
         {max}
-        value={style.thresholds[i] ?? max}
+        value={scale.thresholds[i] ?? max}
         step={0.01}
         class="self-center hover:border-transparent"
-        disabled={i === style.thresholds.length}
+        disabled={i === scale.thresholds.length}
         onchange={onThresholdChange(i)}
       />
     </div>

--- a/src/lib/core/diff/index.ts
+++ b/src/lib/core/diff/index.ts
@@ -222,7 +222,6 @@ interface HeatmapWeightAttributeDiff extends LayerDiff {
   };
 }
 
-
 interface FillColorRampDiff extends LayerDiff {
   type: 'fill-color-ramp';
   payload: {

--- a/src/lib/core/diff/index.ts
+++ b/src/lib/core/diff/index.ts
@@ -10,15 +10,15 @@ import type {
   BasemapProvider,
   CartoKitLayer,
   CategoricalColorScheme,
-  QuantitativeColorRamp,
   LayerType,
   Projection,
+  QuantitativeColorRamp,
+  QuantitativeColorScale,
   QuantitativeColorScheme,
   RampDirection,
   SchemeDirection,
   TransformationCall,
-  VisualizationType,
-  QuantitativeColorScale
+  VisualizationType
 } from '$lib/types';
 
 interface LayerDiff {
@@ -90,7 +90,7 @@ interface FillOpacityDiff extends LayerDiff {
   };
 }
 
-interface FillVisualizationDiff extends LayerDiff {
+interface FillVisualizationTypeDiff extends LayerDiff {
   type: 'fill-visualization-type';
   payload: {
     visualizationType: VisualizationType;
@@ -356,7 +356,7 @@ export type CartoKitDiff =
   | FillClassificationMethodDiff
   | FillStepCountDiff
   | FillStepValueDiff
-  | FillVisualizationDiff
+  | FillVisualizationTypeDiff
   | FillOpacityDiff
   | AddFillDiff
   | RemoveFillDiff

--- a/src/lib/core/diff/index.ts
+++ b/src/lib/core/diff/index.ts
@@ -222,6 +222,21 @@ interface HeatmapWeightAttributeDiff extends LayerDiff {
   };
 }
 
+
+interface FillColorRampDiff extends LayerDiff {
+  type: 'fill-color-ramp';
+  payload: {
+    ramp: QuantitativeColorRamp;
+  };
+}
+
+interface FillColorRampDirectionDiff extends LayerDiff {
+  type: 'fill-color-ramp-direction';
+  payload: {
+    direction: RampDirection;
+  };
+}
+
 interface HeatmapWeightMinDiff extends LayerDiff {
   type: 'heatmap-weight-min';
   payload: {
@@ -337,6 +352,8 @@ export type CartoKitDiff =
   | FillColorDiff
   | FillColorSchemeDiff
   | FillColorSchemeDirectionDiff
+  | FillColorRampDiff
+  | FillColorRampDirectionDiff
   | FillClassificationMethodDiff
   | FillStepCountDiff
   | FillStepValueDiff

--- a/src/lib/core/diff/index.ts
+++ b/src/lib/core/diff/index.ts
@@ -10,15 +10,15 @@ import type {
   BasemapProvider,
   CartoKitLayer,
   CategoricalColorScheme,
-  ClassificationMethod,
-  ColorRamp,
+  QuantitativeColorRamp,
   LayerType,
   Projection,
   QuantitativeColorScheme,
   RampDirection,
   SchemeDirection,
   TransformationCall,
-  VisualizationType
+  VisualizationType,
+  QuantitativeColorScale
 } from '$lib/types';
 
 interface LayerDiff {
@@ -64,7 +64,7 @@ interface FillColorSchemeDirectionDiff extends LayerDiff {
 interface FillClassificationMethodDiff extends LayerDiff {
   type: 'fill-classification-method';
   payload: {
-    method: ClassificationMethod;
+    method: QuantitativeColorScale['type'];
   };
 }
 
@@ -197,7 +197,7 @@ interface HeatmapRadiusDiff extends LayerDiff {
 interface HeatmapRampDiff extends LayerDiff {
   type: 'heatmap-ramp';
   payload: {
-    ramp: ColorRamp;
+    ramp: QuantitativeColorRamp;
   };
 }
 

--- a/src/lib/core/patch/fill/index.ts
+++ b/src/lib/core/patch/fill/index.ts
@@ -1,5 +1,6 @@
 import * as d3 from 'd3';
 
+import type { CartoKitDiff } from '$lib/core/diff';
 import type { PatchFnParams, PatchFnResult } from '$lib/core/patch';
 import { deriveThresholds } from '$lib/interaction/scales';
 import type {
@@ -8,16 +9,16 @@ import type {
   CartoKitPointLayer,
   CartoKitPolygonLayer,
   CartoKitProportionalSymbolLayer,
-  QuantitativeColorScale,
+  CategoricalColorScale,
   ContinuousColorScale,
-  CategoricalColorScale
+  QuantitativeColorScale
 } from '$lib/types';
 import { randomColor } from '$lib/utils/color';
 import {
-  enumerateAttributeCategories,
-  selectCategoricalAttribute,
-  selectQuantitativeAttribute
-} from '$lib/utils/geojson';
+  convertRampToScheme,
+  convertSchemeToRamp
+} from '$lib/utils/color/converter';
+import { materializeColorScheme } from '$lib/utils/color/scheme';
 import {
   DEFAULT_CATEGORICAL_SCHEME,
   DEFAULT_COUNT,
@@ -26,19 +27,19 @@ import {
   DEFAULT_SCHEME_DIRECTION,
   DEFAULT_THRESHOLDS
 } from '$lib/utils/constants';
-import type { CartoKitDiff } from '$lib/core/diff';
 import {
-  convertRampToScheme,
-  convertSchemeToRamp
-} from '$lib/utils/color/converter';
-import { materializeColorScheme } from '$lib/utils/color/scheme';
+  enumerateAttributeCategories,
+  selectCategoricalAttribute,
+  selectQuantitativeAttribute
+} from '$lib/utils/geojson';
 
 /**
  * Recompute the quantitative breaks for a given layer and fill style.
  *
  * @param layerId The ID of the {@link CartoKitLayer}.
- * @param fill The current {@link QuantitativeFill} style.
- * @returns The new breaks for the given layer and fill style.
+ * @param attribute The attribute to use for computing breaks.
+ * @param scale The current {@link QuantitativeColorScale} style.
+ * @returns The new breaks for the given layer, attribute, and color scale.
  */
 function recomputeBreaks(
   layerId: string,
@@ -94,12 +95,7 @@ export async function patchFillDiffs(
         // Apply the patch.
         layer.style.fill.attribute = diff.payload.attribute;
 
-        if (layer.style.fill.scale.type === 'Continuous') {
-          // TODO: Consider what we'll need to do for continuous color scales.
-          // My hunch is that we may not need to do anything; the catalog should
-          // already contain min and max values that we can use to derive the
-          // color scale in deriveColorScale.
-        } else {
+        if (layer.style.fill.scale.type !== 'Continuous') {
           layer.style.fill.scale.thresholds = recomputeBreaks(
             layer.id,
             layer.style.fill.attribute,
@@ -118,6 +114,7 @@ export async function patchFillDiffs(
 
         // Apply the patch.
         layer.style.fill.attribute = diff.payload.attribute;
+
         layer.style.fill.scale.categories = enumerateAttributeCategories(
           layer.data.geojson.features,
           layer.style.fill.attribute

--- a/src/lib/core/patch/fill/index.ts
+++ b/src/lib/core/patch/fill/index.ts
@@ -8,7 +8,9 @@ import type {
   CartoKitPointLayer,
   CartoKitPolygonLayer,
   CartoKitProportionalSymbolLayer,
-  QuantitativeFill
+  QuantitativeColorScale,
+  ContinuousColorScale,
+  CategoricalColorScale
 } from '$lib/types';
 import { randomColor } from '$lib/utils/color';
 import {
@@ -19,10 +21,17 @@ import {
 import {
   DEFAULT_CATEGORICAL_SCHEME,
   DEFAULT_COUNT,
+  DEFAULT_METHOD,
   DEFAULT_QUANTITATIVE_SCHEME,
+  DEFAULT_SCHEME_DIRECTION,
   DEFAULT_THRESHOLDS
 } from '$lib/utils/constants';
 import type { CartoKitDiff } from '$lib/core/diff';
+import {
+  convertRampToScheme,
+  convertSchemeToRamp
+} from '$lib/utils/color/converter';
+import { materializeColorScheme } from '$lib/utils/color/scheme';
 
 /**
  * Recompute the quantitative breaks for a given layer and fill style.
@@ -31,16 +40,22 @@ import type { CartoKitDiff } from '$lib/core/diff';
  * @param fill The current {@link QuantitativeFill} style.
  * @returns The new breaks for the given layer and fill style.
  */
-function recomputeBreaks(layerId: string, fill: QuantitativeFill) {
-  const colors = d3[fill.scheme.id][fill.count];
+function recomputeBreaks(
+  layerId: string,
+  attribute: string,
+  scale: Exclude<QuantitativeColorScale, ContinuousColorScale>
+) {
+  const colors = d3[scale.scheme.id][scale.steps];
 
   return deriveThresholds({
-    method: fill.method,
+    method: scale.type,
     layerId,
-    attribute: fill.attribute,
+    attribute,
     range:
-      fill.scheme.direction === 'Reverse' ? [...colors].reverse() : [...colors],
-    thresholds: fill.thresholds
+      scale.scheme.direction === 'Reverse'
+        ? [...colors].reverse()
+        : [...colors],
+    thresholds: scale.thresholds
   });
 }
 
@@ -78,10 +93,19 @@ export async function patchFillDiffs(
 
         // Apply the patch.
         layer.style.fill.attribute = diff.payload.attribute;
-        layer.style.fill.thresholds = recomputeBreaks(
-          layer.id,
-          layer.style.fill
-        );
+
+        if (layer.style.fill.scale.type === 'Continuous') {
+          // TODO: Consider what we'll need to do for continuous color scales.
+          // My hunch is that we may not need to do anything; the catalog should
+          // already contain min and max values that we can use to derive the
+          // color scale in deriveColorScale.
+        } else {
+          layer.style.fill.scale.thresholds = recomputeBreaks(
+            layer.id,
+            layer.style.fill.attribute,
+            layer.style.fill.scale
+          );
+        }
       } else if (layer.style.fill.type === 'Categorical') {
         // Derive the inverse diff prior to applying the patch.
         inverse = {
@@ -94,7 +118,7 @@ export async function patchFillDiffs(
 
         // Apply the patch.
         layer.style.fill.attribute = diff.payload.attribute;
-        layer.style.fill.categories = enumerateAttributeCategories(
+        layer.style.fill.scale.categories = enumerateAttributeCategories(
           layer.data.geojson.features,
           layer.style.fill.attribute
         );
@@ -131,20 +155,25 @@ export async function patchFillDiffs(
         | CartoKitProportionalSymbolLayer;
 
       if (
-        layer.style.fill.type === 'Quantitative' ||
+        (layer.style.fill.type === 'Quantitative' &&
+          layer.style.fill.scale.type !== 'Continuous') ||
         layer.style.fill.type === 'Categorical'
       ) {
+        const currentScale = layer.style.fill.scale as
+          | Exclude<QuantitativeColorScale, ContinuousColorScale>
+          | CategoricalColorScale;
+
         // Derive the inverse diff prior to applying the patch.
         inverse = {
           type: 'fill-color-scheme',
           layerId: diff.layerId,
           payload: {
-            scheme: layer.style.fill.scheme.id
+            scheme: currentScale.scheme.id
           }
         };
 
         // Apply the patch.
-        layer.style.fill.scheme.id = diff.payload.scheme;
+        currentScale.scheme.id = diff.payload.scheme;
       }
 
       break;
@@ -164,12 +193,20 @@ export async function patchFillDiffs(
           type: 'fill-color-scheme-direction',
           layerId: diff.layerId,
           payload: {
-            direction: layer.style.fill.scheme.direction
+            direction: (
+              layer.style.fill.scale as
+                | Exclude<QuantitativeColorScale, ContinuousColorScale>
+                | CategoricalColorScale
+            ).scheme.direction
           }
         };
 
         // Apply the patch.
-        layer.style.fill.scheme.direction = diff.payload.direction;
+        (
+          layer.style.fill.scale as
+            | Exclude<QuantitativeColorScale, ContinuousColorScale>
+            | CategoricalColorScale
+        ).scheme.direction = diff.payload.direction;
       }
 
       break;
@@ -186,16 +223,65 @@ export async function patchFillDiffs(
           type: 'fill-classification-method',
           layerId: diff.layerId,
           payload: {
-            method: layer.style.fill.method
+            method: layer.style.fill.scale.type
           }
         };
 
-        // Apply the patch.
-        layer.style.fill.method = diff.payload.method;
-        layer.style.fill.thresholds = recomputeBreaks(
-          layer.id,
-          layer.style.fill
-        );
+        // If transitioning from a discrete to a continuous color scale or vice
+        // versa, build the color scale wholesale.
+        if (
+          diff.payload.method === 'Continuous' &&
+          layer.style.fill.scale.type !== 'Continuous'
+        ) {
+          layer.style.fill.scale = {
+            type: diff.payload.method,
+            interpolator: {
+              id: convertSchemeToRamp(layer.style.fill.scale.scheme.id),
+              direction: layer.style.fill.scale.scheme.direction
+            }
+          };
+        } else if (
+          diff.payload.method !== 'Continuous' &&
+          layer.style.fill.scale.type === 'Continuous'
+        ) {
+          const scheme = {
+            id: convertRampToScheme(layer.style.fill.scale.interpolator.id),
+            direction: layer.style.fill.scale.interpolator.direction
+          };
+
+          const range = materializeColorScheme(
+            scheme.id,
+            scheme.direction,
+            DEFAULT_COUNT
+          );
+
+          layer.style.fill.scale = {
+            type: diff.payload.method,
+            scheme,
+            steps: DEFAULT_COUNT,
+            thresholds: deriveThresholds({
+              method: diff.payload.method,
+              layerId: layer.id,
+              attribute: layer.style.fill.attribute,
+              range,
+              thresholds: DEFAULT_THRESHOLDS(
+                layer.id,
+                layer.style.fill.attribute
+              )
+            })
+          };
+        } else if (
+          diff.payload.method !== 'Continuous' &&
+          layer.style.fill.scale.type !== 'Continuous'
+        ) {
+          // Just recompute the thresholds.
+          layer.style.fill.scale.type = diff.payload.method;
+          layer.style.fill.scale.thresholds = recomputeBreaks(
+            layer.id,
+            layer.style.fill.attribute,
+            layer.style.fill.scale
+          );
+        }
       }
 
       break;
@@ -206,21 +292,25 @@ export async function patchFillDiffs(
         | CartoKitPointLayer
         | CartoKitProportionalSymbolLayer;
 
-      if (layer.style.fill.type === 'Quantitative') {
+      if (
+        layer.style.fill.type === 'Quantitative' &&
+        layer.style.fill.scale.type !== 'Continuous'
+      ) {
         // Derive the inverse diff prior to applying the patch.
         inverse = {
           type: 'fill-step-count',
           layerId: diff.layerId,
           payload: {
-            count: layer.style.fill.count
+            count: layer.style.fill.scale.steps
           }
         };
 
         // Apply the patch.
-        layer.style.fill.count = diff.payload.count;
-        layer.style.fill.thresholds = recomputeBreaks(
+        layer.style.fill.scale.steps = diff.payload.count;
+        layer.style.fill.scale.thresholds = recomputeBreaks(
           layer.id,
-          layer.style.fill
+          layer.style.fill.attribute,
+          layer.style.fill.scale
         );
       }
 
@@ -232,22 +322,27 @@ export async function patchFillDiffs(
         | CartoKitPointLayer
         | CartoKitProportionalSymbolLayer;
 
-      if (layer.style.fill.type === 'Quantitative') {
+      if (
+        layer.style.fill.type === 'Quantitative' &&
+        layer.style.fill.scale.type === 'Manual'
+      ) {
         // Derive the inverse diff prior to applying the patch.
         inverse = {
           type: 'fill-step-value',
           layerId: diff.layerId,
           payload: {
             step: diff.payload.step,
-            value: layer.style.fill.thresholds[diff.payload.step]
+            value: layer.style.fill.scale.thresholds[diff.payload.step]
           }
         };
 
         // Apply the patch.
-        layer.style.fill.thresholds[diff.payload.step] = diff.payload.value;
-        layer.style.fill.thresholds = recomputeBreaks(
+        layer.style.fill.scale.thresholds[diff.payload.step] =
+          diff.payload.value;
+        layer.style.fill.scale.thresholds = recomputeBreaks(
           layer.id,
-          layer.style.fill
+          layer.style.fill.attribute,
+          layer.style.fill.scale
         );
       }
 
@@ -277,16 +372,16 @@ export async function patchFillDiffs(
           layer.style.fill = {
             type: diff.payload.visualizationType,
             attribute,
-            categories: enumerateAttributeCategories(
-              layer.data.geojson.features,
-              attribute
-            ),
-            scheme: {
-              id: DEFAULT_CATEGORICAL_SCHEME,
-              direction:
-                'scheme' in layer.style.fill
-                  ? layer.style.fill.scheme.direction
-                  : 'Forward'
+            scale: {
+              type: 'Categorical',
+              scheme: {
+                id: DEFAULT_CATEGORICAL_SCHEME,
+                direction: 'Forward'
+              },
+              categories: enumerateAttributeCategories(
+                layer.data.geojson.features,
+                attribute
+              )
             },
             opacity: layer.style.fill.opacity,
             visible: layer.style.fill.visible
@@ -301,16 +396,15 @@ export async function patchFillDiffs(
           layer.style.fill = {
             type: diff.payload.visualizationType,
             attribute: attribute,
-            method: 'Quantile',
-            scheme: {
-              id: DEFAULT_QUANTITATIVE_SCHEME,
-              direction:
-                layer.style.fill && 'scheme' in layer.style.fill
-                  ? layer.style.fill.scheme.direction
-                  : 'Forward'
+            scale: {
+              type: DEFAULT_METHOD,
+              scheme: {
+                id: DEFAULT_QUANTITATIVE_SCHEME,
+                direction: DEFAULT_SCHEME_DIRECTION
+              },
+              steps: DEFAULT_COUNT,
+              thresholds: DEFAULT_THRESHOLDS(layer.id, attribute)
             },
-            count: DEFAULT_COUNT,
-            thresholds: DEFAULT_THRESHOLDS(layer.id, attribute),
             opacity: layer.style.fill.opacity,
             visible: layer.style.fill.visible
           };

--- a/src/lib/core/patch/fill/index.ts
+++ b/src/lib/core/patch/fill/index.ts
@@ -148,6 +148,56 @@ export async function patchFillDiffs(
 
       break;
     }
+    case 'fill-color-ramp': {
+      const layer = ir.layers[diff.layerId] as
+        | CartoKitChoroplethLayer
+        | CartoKitPointLayer
+        | CartoKitProportionalSymbolLayer;
+
+      if (
+        layer.style.fill.type === 'Quantitative' &&
+        layer.style.fill.scale.type === 'Continuous'
+      ) {
+        // Derive the inverse diff prior to applying the patch.
+        inverse = {
+          type: 'fill-color-ramp',
+          layerId: diff.layerId,
+          payload: {
+            ramp: layer.style.fill.scale.interpolator.id
+          }
+        };
+
+        // Apply the patch.
+        layer.style.fill.scale.interpolator.id = diff.payload.ramp;
+      }
+
+      break;
+    }
+    case 'fill-color-ramp-direction': {
+      const layer = ir.layers[diff.layerId] as
+        | CartoKitChoroplethLayer
+        | CartoKitPointLayer
+        | CartoKitProportionalSymbolLayer;
+
+      if (
+        layer.style.fill.type === 'Quantitative' &&
+        layer.style.fill.scale.type === 'Continuous'
+      ) {
+        // Derive the inverse diff prior to applying the patch.
+        inverse = {
+          type: 'fill-color-ramp-direction',
+          layerId: diff.layerId,
+          payload: {
+            direction: layer.style.fill.scale.interpolator.direction
+          }
+        };
+
+        // Apply the patch.
+        layer.style.fill.scale.interpolator.direction = diff.payload.direction;
+      }
+
+      break;
+    }
     case 'fill-color-scheme': {
       const layer = ir.layers[diff.layerId] as
         | CartoKitChoroplethLayer

--- a/src/lib/core/patch/layer-type/choropleth.ts
+++ b/src/lib/core/patch/layer-type/choropleth.ts
@@ -39,13 +39,18 @@ export function patchChoropleth(layer: CartoKitLayer): CartoKitChoroplethLayer {
           fill: {
             type: 'Quantitative',
             attribute: layer.style.dot.attribute,
-            method: DEFAULT_METHOD,
-            scheme: {
-              id: DEFAULT_QUANTITATIVE_SCHEME,
-              direction: DEFAULT_SCHEME_DIRECTION
+            scale: {
+              type: DEFAULT_METHOD,
+              scheme: {
+                id: DEFAULT_QUANTITATIVE_SCHEME,
+                direction: DEFAULT_SCHEME_DIRECTION
+              },
+              steps: DEFAULT_COUNT,
+              thresholds: DEFAULT_THRESHOLDS(
+                layer.id,
+                layer.style.dot.attribute
+              )
             },
-            count: DEFAULT_COUNT,
-            thresholds: DEFAULT_THRESHOLDS(layer.id, layer.style.dot.attribute),
             opacity: layer.style.fill.opacity,
             visible: layer.style.fill.visible
           },
@@ -91,13 +96,15 @@ export function patchChoropleth(layer: CartoKitLayer): CartoKitChoroplethLayer {
               : {
                   type: 'Quantitative',
                   attribute,
-                  method: DEFAULT_METHOD,
-                  scheme: {
-                    id: DEFAULT_QUANTITATIVE_SCHEME,
-                    direction: DEFAULT_SCHEME_DIRECTION
+                  scale: {
+                    type: DEFAULT_METHOD,
+                    scheme: {
+                      id: DEFAULT_QUANTITATIVE_SCHEME,
+                      direction: DEFAULT_SCHEME_DIRECTION
+                    },
+                    steps: DEFAULT_COUNT,
+                    thresholds: DEFAULT_THRESHOLDS(layer.id, attribute)
                   },
-                  count: DEFAULT_COUNT,
-                  thresholds: DEFAULT_THRESHOLDS(layer.id, attribute),
                   opacity: layer.style.fill.opacity,
                   visible: layer.style.fill.visible
                 },
@@ -122,13 +129,15 @@ export function patchChoropleth(layer: CartoKitLayer): CartoKitChoroplethLayer {
           fill: {
             type: 'Quantitative',
             attribute,
-            method: DEFAULT_METHOD,
-            scheme: {
-              id: DEFAULT_QUANTITATIVE_SCHEME,
-              direction: 'Forward'
+            scale: {
+              type: DEFAULT_METHOD,
+              scheme: {
+                id: DEFAULT_QUANTITATIVE_SCHEME,
+                direction: DEFAULT_SCHEME_DIRECTION
+              },
+              steps: DEFAULT_COUNT,
+              thresholds: DEFAULT_THRESHOLDS(layer.id, attribute)
             },
-            count: DEFAULT_COUNT,
-            thresholds: DEFAULT_THRESHOLDS(layer.id, attribute),
             opacity: layer.style.fill.opacity,
             visible: layer.style.fill.visible
           },

--- a/src/lib/core/recon/fill/index.ts
+++ b/src/lib/core/recon/fill/index.ts
@@ -26,6 +26,8 @@ export async function reconFillDiffs(
     case 'fill-attribute':
     case 'fill-color-scheme':
     case 'fill-color-scheme-direction':
+    case 'fill-color-ramp':
+    case 'fill-color-ramp-direction':
     case 'fill-classification-method':
     case 'fill-step-count':
     case 'fill-step-value':
@@ -40,7 +42,7 @@ export async function reconFillDiffs(
           map.value!.setPaintProperty(
             diff.layerId,
             'fill-color',
-            deriveColorScale(layer.style.fill)
+            deriveColorScale(layer.style.fill, layer.id)
           );
           break;
         case 'Point':
@@ -48,7 +50,7 @@ export async function reconFillDiffs(
           map.value!.setPaintProperty(
             diff.layerId,
             'circle-color',
-            deriveColorScale(layer.style.fill)
+            deriveColorScale(layer.style.fill, layer.id)
           );
           break;
       }
@@ -124,7 +126,7 @@ export async function reconFillDiffs(
           map.value!.setPaintProperty(
             diff.layerId,
             'circle-color',
-            deriveColorScale(layer.style.fill)
+            deriveColorScale(layer.style.fill, layer.id)
           );
           map.value!.setPaintProperty(
             diff.layerId,
@@ -136,7 +138,7 @@ export async function reconFillDiffs(
           map.value!.setPaintProperty(
             diff.layerId,
             'fill-color',
-            deriveColorScale(layer.style.fill)
+            deriveColorScale(layer.style.fill, layer.id)
           );
           map.value!.setPaintProperty(
             diff.layerId,

--- a/src/lib/core/recon/layer-type/choropleth.ts
+++ b/src/lib/core/recon/layer-type/choropleth.ts
@@ -35,7 +35,7 @@ export function reconChoropleth(
       map.value?.setPaintProperty(
         targetLayer.id,
         'fill-color',
-        deriveColorScale(targetLayer.style.fill)
+        deriveColorScale(targetLayer.style.fill, targetLayer.id)
       );
   }
 }

--- a/src/lib/interaction/color.spec.ts
+++ b/src/lib/interaction/color.spec.ts
@@ -23,7 +23,7 @@ describe('deriveColorScale', () => {
         },
         opacity: 1,
         visible: true
-      });
+      }, 'test-layer');
 
       expect(result).toEqual([
         'step',
@@ -59,7 +59,7 @@ describe('deriveColorScale', () => {
         },
         opacity: 1,
         visible: true
-      });
+      }, 'test-layer');
 
       expect(result).toEqual([
         'step',
@@ -105,7 +105,7 @@ describe('deriveColorScale', () => {
         },
         opacity: 1,
         visible: true
-      });
+      }, 'test-layer');
 
       expect(result).toEqual([
         'match',
@@ -160,7 +160,7 @@ describe('deriveColorScale', () => {
         },
         opacity: 1,
         visible: true
-      });
+      }, 'test-layer');
 
       expect(result).toEqual([
         'match',
@@ -212,7 +212,7 @@ describe('deriveColorScale', () => {
         },
         opacity: 1,
         visible: true
-      });
+      }, 'test-layer');
 
       expect(result).toEqual([
         'match',
@@ -245,7 +245,7 @@ describe('deriveColorScale', () => {
         color: '#c6abdd',
         opacity: 1,
         visible: true
-      });
+      }, 'test-layer');
 
       expect(result).toEqual('#c6abdd');
     });

--- a/src/lib/interaction/color.spec.ts
+++ b/src/lib/interaction/color.spec.ts
@@ -9,21 +9,24 @@ describe('deriveColorScale', () => {
     const STOPS = 7;
 
     test('should derive a quantitative color scale', () => {
-      const result = deriveColorScale({
-        type: 'Quantitative',
-        attribute: 'total_capacity',
-        scale: {
-          type: 'Quantile',
-          scheme: {
-            id: 'schemeBlues',
-            direction: 'Forward'
+      const result = deriveColorScale(
+        {
+          type: 'Quantitative',
+          attribute: 'total_capacity',
+          scale: {
+            type: 'Quantile',
+            scheme: {
+              id: 'schemeBlues',
+              direction: 'Forward'
+            },
+            steps: STOPS,
+            thresholds: [1.6, 2.8, 5, 10.8, 42, 151.63]
           },
-          steps: STOPS,
-          thresholds: [1.6, 2.8, 5, 10.8, 42, 151.63]
+          opacity: 1,
+          visible: true
         },
-        opacity: 1,
-        visible: true
-      }, 'test-layer');
+        'test-layer'
+      );
 
       expect(result).toEqual([
         'step',
@@ -45,21 +48,24 @@ describe('deriveColorScale', () => {
     });
 
     test('should derive a quantitative color scale with a reverse direction', () => {
-      const result = deriveColorScale({
-        type: 'Quantitative',
-        attribute: 'total_capacity',
-        scale: {
-          type: 'Quantile',
-          scheme: {
-            id: 'schemeBlues',
-            direction: 'Reverse'
+      const result = deriveColorScale(
+        {
+          type: 'Quantitative',
+          attribute: 'total_capacity',
+          scale: {
+            type: 'Quantile',
+            scheme: {
+              id: 'schemeBlues',
+              direction: 'Reverse'
+            },
+            steps: STOPS,
+            thresholds: [1.6, 2.8, 5, 10.8, 42, 151.63]
           },
-          steps: STOPS,
-          thresholds: [1.6, 2.8, 5, 10.8, 42, 151.63]
+          opacity: 1,
+          visible: true
         },
-        opacity: 1,
-        visible: true
-      }, 'test-layer');
+        'test-layer'
+      );
 
       expect(result).toEqual([
         'step',
@@ -83,29 +89,32 @@ describe('deriveColorScale', () => {
 
   describe('Categorical', () => {
     test('should derive a categorical color scale with fewer categories than colors in the scheme', () => {
-      const result = deriveColorScale({
-        type: 'Categorical',
-        attribute: 'primary_source',
-        scale: {
+      const result = deriveColorScale(
+        {
           type: 'Categorical',
-          scheme: {
-            id: 'schemeCategory10',
-            direction: 'Forward'
+          attribute: 'primary_source',
+          scale: {
+            type: 'Categorical',
+            scheme: {
+              id: 'schemeCategory10',
+              direction: 'Forward'
+            },
+            categories: [
+              'oil',
+              'hydroelectric',
+              'natural gas',
+              'nuclear',
+              'coal',
+              'other',
+              'wind',
+              'solar'
+            ]
           },
-          categories: [
-            'oil',
-            'hydroelectric',
-            'natural gas',
-            'nuclear',
-            'coal',
-            'other',
-            'wind',
-            'solar'
-          ]
+          opacity: 1,
+          visible: true
         },
-        opacity: 1,
-        visible: true
-      }, 'test-layer');
+        'test-layer'
+      );
 
       expect(result).toEqual([
         'match',
@@ -131,36 +140,39 @@ describe('deriveColorScale', () => {
     });
 
     test('should derive a categorical color scale with more categories than colors in the scheme, applying the DEFAULT_FILL to unmatched categories', () => {
-      const result = deriveColorScale({
-        type: 'Categorical',
-        attribute: 'county',
-        scale: {
+      const result = deriveColorScale(
+        {
           type: 'Categorical',
-          scheme: {
-            id: 'schemeCategory10',
-            direction: 'Forward'
+          attribute: 'county',
+          scale: {
+            type: 'Categorical',
+            scheme: {
+              id: 'schemeCategory10',
+              direction: 'Forward'
+            },
+            categories: [
+              'Aleutians East',
+              'Tuscaloosa',
+              'Mobile',
+              'Elmore',
+              'Etowah',
+              'El Paso',
+              'Greene',
+              'Calhoun',
+              'Talladega',
+              'Chilton',
+              'Coosa',
+              'Walker',
+              'Cherokee',
+              'Shelby',
+              'Watonwan'
+            ]
           },
-          categories: [
-            'Aleutians East',
-            'Tuscaloosa',
-            'Mobile',
-            'Elmore',
-            'Etowah',
-            'El Paso',
-            'Greene',
-            'Calhoun',
-            'Talladega',
-            'Chilton',
-            'Coosa',
-            'Walker',
-            'Cherokee',
-            'Shelby',
-            'Watonwan'
-          ]
+          opacity: 1,
+          visible: true
         },
-        opacity: 1,
-        visible: true
-      }, 'test-layer');
+        'test-layer'
+      );
 
       expect(result).toEqual([
         'match',
@@ -190,29 +202,32 @@ describe('deriveColorScale', () => {
     });
 
     test('should derive a categorical color scale with a reverse direction', () => {
-      const result = deriveColorScale({
-        type: 'Categorical',
-        attribute: 'primary_source',
-        scale: {
+      const result = deriveColorScale(
+        {
           type: 'Categorical',
-          scheme: {
-            id: 'schemeCategory10',
-            direction: 'Reverse'
+          attribute: 'primary_source',
+          scale: {
+            type: 'Categorical',
+            scheme: {
+              id: 'schemeCategory10',
+              direction: 'Reverse'
+            },
+            categories: [
+              'oil',
+              'hydroelectric',
+              'natural gas',
+              'nuclear',
+              'coal',
+              'other',
+              'wind',
+              'solar'
+            ]
           },
-          categories: [
-            'oil',
-            'hydroelectric',
-            'natural gas',
-            'nuclear',
-            'coal',
-            'other',
-            'wind',
-            'solar'
-          ]
+          opacity: 1,
+          visible: true
         },
-        opacity: 1,
-        visible: true
-      }, 'test-layer');
+        'test-layer'
+      );
 
       expect(result).toEqual([
         'match',
@@ -240,12 +255,15 @@ describe('deriveColorScale', () => {
 
   describe('Constant', () => {
     test('should derive a constant color scale', () => {
-      const result = deriveColorScale({
-        type: 'Constant',
-        color: '#c6abdd',
-        opacity: 1,
-        visible: true
-      }, 'test-layer');
+      const result = deriveColorScale(
+        {
+          type: 'Constant',
+          color: '#c6abdd',
+          opacity: 1,
+          visible: true
+        },
+        'test-layer'
+      );
 
       expect(result).toEqual('#c6abdd');
     });

--- a/src/lib/interaction/color.spec.ts
+++ b/src/lib/interaction/color.spec.ts
@@ -12,13 +12,15 @@ describe('deriveColorScale', () => {
       const result = deriveColorScale({
         type: 'Quantitative',
         attribute: 'total_capacity',
-        scheme: {
-          id: 'schemeBlues',
-          direction: 'Forward'
+        scale: {
+          type: 'Quantile',
+          scheme: {
+            id: 'schemeBlues',
+            direction: 'Forward'
+          },
+          steps: STOPS,
+          thresholds: [1.6, 2.8, 5, 10.8, 42, 151.63]
         },
-        method: 'Quantile',
-        count: STOPS,
-        thresholds: [1.6, 2.8, 5, 10.8, 42, 151.63],
         opacity: 1,
         visible: true
       });
@@ -46,13 +48,15 @@ describe('deriveColorScale', () => {
       const result = deriveColorScale({
         type: 'Quantitative',
         attribute: 'total_capacity',
-        scheme: {
-          id: 'schemeBlues',
-          direction: 'Reverse'
+        scale: {
+          type: 'Quantile',
+          scheme: {
+            id: 'schemeBlues',
+            direction: 'Reverse'
+          },
+          steps: STOPS,
+          thresholds: [1.6, 2.8, 5, 10.8, 42, 151.63]
         },
-        method: 'Quantile',
-        count: STOPS,
-        thresholds: [1.6, 2.8, 5, 10.8, 42, 151.63],
         opacity: 1,
         visible: true
       });
@@ -82,19 +86,22 @@ describe('deriveColorScale', () => {
       const result = deriveColorScale({
         type: 'Categorical',
         attribute: 'primary_source',
-        categories: [
-          'oil',
-          'hydroelectric',
-          'natural gas',
-          'nuclear',
-          'coal',
-          'other',
-          'wind',
-          'solar'
-        ],
-        scheme: {
-          id: 'schemeCategory10',
-          direction: 'Forward'
+        scale: {
+          type: 'Categorical',
+          scheme: {
+            id: 'schemeCategory10',
+            direction: 'Forward'
+          },
+          categories: [
+            'oil',
+            'hydroelectric',
+            'natural gas',
+            'nuclear',
+            'coal',
+            'other',
+            'wind',
+            'solar'
+          ]
         },
         opacity: 1,
         visible: true
@@ -127,26 +134,29 @@ describe('deriveColorScale', () => {
       const result = deriveColorScale({
         type: 'Categorical',
         attribute: 'county',
-        categories: [
-          'Aleutians East',
-          'Tuscaloosa',
-          'Mobile',
-          'Elmore',
-          'Etowah',
-          'El Paso',
-          'Greene',
-          'Calhoun',
-          'Talladega',
-          'Chilton',
-          'Coosa',
-          'Walker',
-          'Cherokee',
-          'Shelby',
-          'Watonwan'
-        ],
-        scheme: {
-          id: 'schemeCategory10',
-          direction: 'Forward'
+        scale: {
+          type: 'Categorical',
+          scheme: {
+            id: 'schemeCategory10',
+            direction: 'Forward'
+          },
+          categories: [
+            'Aleutians East',
+            'Tuscaloosa',
+            'Mobile',
+            'Elmore',
+            'Etowah',
+            'El Paso',
+            'Greene',
+            'Calhoun',
+            'Talladega',
+            'Chilton',
+            'Coosa',
+            'Walker',
+            'Cherokee',
+            'Shelby',
+            'Watonwan'
+          ]
         },
         opacity: 1,
         visible: true
@@ -183,19 +193,22 @@ describe('deriveColorScale', () => {
       const result = deriveColorScale({
         type: 'Categorical',
         attribute: 'primary_source',
-        categories: [
-          'oil',
-          'hydroelectric',
-          'natural gas',
-          'nuclear',
-          'coal',
-          'other',
-          'wind',
-          'solar'
-        ],
-        scheme: {
-          id: 'schemeCategory10',
-          direction: 'Reverse'
+        scale: {
+          type: 'Categorical',
+          scheme: {
+            id: 'schemeCategory10',
+            direction: 'Reverse'
+          },
+          categories: [
+            'oil',
+            'hydroelectric',
+            'natural gas',
+            'nuclear',
+            'coal',
+            'other',
+            'wind',
+            'solar'
+          ]
         },
         opacity: 1,
         visible: true
@@ -247,7 +260,7 @@ describe('deriveColorRamp', () => {
         value: 1
       },
       ramp: {
-        id: 'Spectral',
+        id: 'interpolateSpectral',
         direction: 'Forward'
       },
       radius: 10,
@@ -294,7 +307,7 @@ describe('deriveColorRamp', () => {
         value: 1
       },
       ramp: {
-        id: 'Spectral',
+        id: 'interpolateSpectral',
         direction: 'Reverse'
       },
       radius: 10,

--- a/src/lib/interaction/color.ts
+++ b/src/lib/interaction/color.ts
@@ -15,43 +15,51 @@ import { materializeColorScheme } from '$lib/utils/color/scheme';
 /**
  * Derive a MapLibre GL JS expression for a choropleth color scale.
  *
- * @param {ConstantStyle | CategoricalStyle | QuantitativeStyle} style – The
- * style from which to derive the color scale.
- * @returns {ExpressionSpecification | string} — A MapLibre GL JS expression for
- * a color scale.
+ * @param style The {@link ConstantStyle}, {@link CategoricalStyle}, or
+ * {@link QuantitativeStyle} from which to derive the color scale.
+ * @returns An {@link ExpressionSpecification} or string for a color scale.
  */
 export function deriveColorScale(
   style: ConstantStyle | CategoricalStyle | QuantitativeStyle
 ): ExpressionSpecification | string {
   switch (style.type) {
     case 'Quantitative': {
-      const { scheme, count, attribute, thresholds } = style;
+      const { scale, attribute } = style;
 
-      const colors = materializeColorScheme(scheme.id, scheme.direction, count);
+      if (scale.type === 'Continuous') {
+        // TODO: Implement continuous color scale.
+        return 'TODO';
+      } else {
+        const colors = materializeColorScheme(
+          scale.scheme.id,
+          scale.scheme.direction,
+          scale.steps
+        );
 
-      const prelude: ExpressionSpecification = [
-        'step',
-        ['get', attribute],
-        colors[0]
-      ];
-      const stops = colors.reduce<(string | number)[]>(
-        (acc, color, i) =>
-          i === 0 ? acc : acc.concat([thresholds[i - 1], color]),
-        []
-      );
+        const prelude: ExpressionSpecification = [
+          'step',
+          ['get', attribute],
+          colors[0]
+        ];
+        const stops = colors.reduce<(string | number)[]>(
+          (acc, color, i) =>
+            i === 0 ? acc : acc.concat([scale.thresholds[i - 1], color]),
+          []
+        );
 
-      return [...prelude, ...stops];
+        return [...prelude, ...stops];
+      }
     }
     case 'Categorical': {
-      const { categories, scheme, attribute } = style;
+      const { scale, attribute } = style;
 
       const colors = materializeColorScheme(
-        scheme.id,
-        scheme.direction,
-        categories.length
+        scale.scheme.id,
+        scale.scheme.direction,
+        scale.categories.length
       );
 
-      const stops = zip(categories, colors)
+      const stops = zip(scale.categories, colors)
         .filter(
           (pair): pair is [string, string] | [number, string] =>
             pair[0] !== undefined && pair[1] !== undefined
@@ -75,9 +83,8 @@ export function deriveColorScale(
 /**
  * Derive a MapLibre GL JS expression for a color ramp.
  *
- * @param {HeatmapStyle} style – The style from which to derive the color ramp.
- * @returns {ExpressionSpecification} — A MapLibre GL JS expression for a color
- * ramp.
+ * @param style The style from which to derive the color ramp.
+ * @returns An {@link ExpressionSpecification} for a color ramp.
  */
 export function deriveColorRamp(style: HeatmapStyle): ExpressionSpecification {
   const { ramp } = style;

--- a/src/lib/interaction/color.ts
+++ b/src/lib/interaction/color.ts
@@ -22,14 +22,14 @@ import { catalog } from '$lib/state/catalog.svelte';
  */
 export function deriveColorScale(
   style: ConstantStyle | CategoricalStyle | QuantitativeStyle,
-  layerId?: string
+  layerId: string
 ): ExpressionSpecification | string {
   switch (style.type) {
     case 'Quantitative': {
       const { scale, attribute } = style;
 
       if (scale.type === 'Continuous') {
-        const { min, max } = catalog.value[layerId!][attribute];
+        const { min, max } = catalog.value[layerId][attribute];
         const colors = materializeColorRamp(
           scale.interpolator.id,
           scale.interpolator.direction,

--- a/src/lib/interaction/color.ts
+++ b/src/lib/interaction/color.ts
@@ -11,6 +11,7 @@ import type {
 import { DEFAULT_FILL } from '$lib/utils/constants';
 import { materializeColorRamp } from '$lib/utils/color/ramp';
 import { materializeColorScheme } from '$lib/utils/color/scheme';
+import { catalog } from '$lib/state/catalog.svelte';
 
 /**
  * Derive a MapLibre GL JS expression for a choropleth color scale.
@@ -20,15 +21,31 @@ import { materializeColorScheme } from '$lib/utils/color/scheme';
  * @returns An {@link ExpressionSpecification} or string for a color scale.
  */
 export function deriveColorScale(
-  style: ConstantStyle | CategoricalStyle | QuantitativeStyle
+  style: ConstantStyle | CategoricalStyle | QuantitativeStyle,
+  layerId?: string
 ): ExpressionSpecification | string {
   switch (style.type) {
     case 'Quantitative': {
       const { scale, attribute } = style;
 
       if (scale.type === 'Continuous') {
-        // TODO: Implement continuous color scale.
-        return 'TODO';
+        const { min, max } = catalog.value[layerId!][attribute];
+        const colors = materializeColorRamp(
+          scale.interpolator.id,
+          scale.interpolator.direction,
+          10
+        );
+        const step = (max - min) / 10;
+
+        return [
+          'interpolate',
+          ['linear'],
+          ['get', attribute],
+          ...colors.flatMap((color, i) => [
+            parseFloat((min + i * step).toFixed(10)),
+            color
+          ])
+        ];
       } else {
         const colors = materializeColorScheme(
           scale.scheme.id,

--- a/src/lib/interaction/color.ts
+++ b/src/lib/interaction/color.ts
@@ -18,6 +18,7 @@ import { catalog } from '$lib/state/catalog.svelte';
  *
  * @param style The {@link ConstantStyle}, {@link CategoricalStyle}, or
  * {@link QuantitativeStyle} from which to derive the color scale.
+ * @param layerId The ID of the {@link CartoKitLayer}.
  * @returns An {@link ExpressionSpecification} or string for a color scale.
  */
 export function deriveColorScale(
@@ -35,14 +36,14 @@ export function deriveColorScale(
           scale.interpolator.direction,
           10
         );
-        const step = (max - min) / 10;
+        const interpolate = d3.interpolateNumber(min, max);
 
         return [
           'interpolate',
           ['linear'],
           ['get', attribute],
           ...colors.flatMap((color, i) => [
-            parseFloat((min + i * step).toFixed(10)),
+            parseFloat(interpolate(i / 10).toFixed(1)),
             color
           ])
         ];

--- a/src/lib/interaction/layer.ts
+++ b/src/lib/interaction/layer.ts
@@ -28,7 +28,7 @@ export function addLayer(map: maplibregl.Map, layer: CartoKitLayer): void {
         source: layer.id,
         type: 'fill',
         paint: {
-          'fill-color': deriveColorScale(layer.style.fill),
+          'fill-color': deriveColorScale(layer.style.fill, layer.id),
           'fill-opacity': layer.style.fill.opacity
         }
       });
@@ -174,7 +174,7 @@ export function addLayer(map: maplibregl.Map, layer: CartoKitLayer): void {
     case 'Point': {
       const fillPaint = layer.style.fill.visible
         ? {
-            'circle-color': deriveColorScale(layer.style.fill),
+            'circle-color': deriveColorScale(layer.style.fill, layer.id),
             'circle-opacity': layer.style.fill.opacity
           }
         : {
@@ -254,7 +254,7 @@ export function addLayer(map: maplibregl.Map, layer: CartoKitLayer): void {
     case 'Proportional Symbol': {
       const fillPaint = layer.style.fill.visible
         ? {
-            'circle-color': deriveColorScale(layer.style.fill),
+            'circle-color': deriveColorScale(layer.style.fill, layer.id),
             'circle-opacity': layer.style.fill.opacity
           }
         : {

--- a/src/lib/interaction/scales.ts
+++ b/src/lib/interaction/scales.ts
@@ -1,7 +1,7 @@
 import * as d3 from 'd3';
 
 import { catalog } from '$lib/state/catalog.svelte';
-import type { ClassificationMethod } from '$lib/types';
+import type { QuantitativeColorScale } from '$lib/types';
 
 interface DeriveBreaksParams {
   layerId: string;
@@ -12,11 +12,11 @@ interface DeriveBreaksParams {
 /**
  * Derive quantiles for a given attribute of a GeoJSON FeatureCollection.
  *
- * @param params — Input parameters to compute quantiles over a GeoJSON FeatureCollection.
- * @param layerId – The ID of the visualized layer.
- * @param attribute – The data attribute to compute quantiles over.
- * @param range – The output range of the quantile scale.
- * @returns – The quantiles of the dataset.
+ * @param params Input parameters to compute quantiles over a GeoJSON FeatureCollection.
+ * @param layerId The ID of the visualized layer.
+ * @param attribute The data attribute to compute quantiles over.
+ * @param range The output range of the quantile scale.
+ * @returns The quantiles of the dataset.
  */
 function deriveQuantiles({
   layerId,
@@ -38,11 +38,11 @@ function deriveQuantiles({
 /**
  * Derive equal interval thresholds for a given attribute of a GeoJSON FeatureCollection.
  *
- * @param params — Input parameters to compute equal interval thresholds over a GeoJSON FeatureCollection.
- * @param layerId – The ID of the visualized layer.
- * @param attribute – The data attribute to compute equal interval thresholds over.
- * @param range – The output range of the equal interval (quantize) scale.
- * @returns – The equal interval thresholds of the dataset.
+ * @param params Input parameters to compute equal interval thresholds over a GeoJSON FeatureCollection.
+ * @param layerId The ID of the visualized layer.
+ * @param attribute The data attribute to compute equal interval thresholds over.
+ * @param range The output range of the equal interval (quantize) scale.
+ * @returns The equal interval thresholds of the dataset.
  */
 function deriveEqualIntervals({
   layerId,
@@ -64,11 +64,11 @@ function deriveEqualIntervals({
 /**
  * Derive Jenks natural breaks for a given attribute of a GeoJSON FeatureCollection.
  *
- * @param params — Input parameters to compute Jenks natural breaks over a GeoJSON FeatureCollection.
- * @param layerId – The ID of the visualized layer.
- * @param attribute – The data attribute to compute Jenks natural breaks over.
- * @param range – The output range of the Jenks scale.
- * @returns – The Jenks natural breaks of the dataset.
+ * @param params Input parameters to compute Jenks natural breaks over a GeoJSON FeatureCollection.
+ * @param layerId The ID of the visualized layer.
+ * @param attribute The data attribute to compute Jenks natural breaks over.
+ * @param range The output range of the Jenks scale.
+ * @returns The Jenks natural breaks of the dataset.
  */
 function deriveJenksBreaks({
   layerId,
@@ -81,12 +81,12 @@ function deriveJenksBreaks({
 /**
  * Derive manual thresholds for a given attribute of a GeoJSON FeatureCollection.
  *
- * @param params – Input parameters to compute manual thresholds over a GeoJSON FeatureCollection.
- * @param layerId – The ID of the visualized layer.
- * @param attribute – The data attribute to compute manual thresholds over.
- * @param range – The output range of the scale.
- * @param thresholds – The current thresholds of the dataset.
- * @returns – The (potentially updated) manual thresholds of the dataset.
+ * @param params Input parameters to compute manual thresholds over a GeoJSON FeatureCollection.
+ * @param layerId The ID of the visualized layer.
+ * @param attribute The data attribute to compute manual thresholds over.
+ * @param range The output range of the scale.
+ * @param thresholds The current thresholds of the dataset.
+ * @returns The (potentially updated) manual thresholds of the dataset.
  */
 function deriveManualBreaks({
   layerId,
@@ -152,21 +152,21 @@ function forceAscendingThresholds({
 }
 
 interface DeriveThresholdsParams extends DeriveBreaksParams {
-  method: ClassificationMethod;
+  method: Exclude<QuantitativeColorScale['type'], 'Continuous'>;
   thresholds: number[];
 }
 
 /**
  * Obtain the thresholds for a given attribute of a GeoJSON FeatureCollection.
  *
- * @param params – Input parameters to compute thresholds over a GeoJSON FeatureCollection.
- * @param method – The @see{ClassificationMethod} to use.
- * @param layerId – The ID of the visualized layer.
- * @param attribute – The data attribute to compute thresholds over.layerId,
- * @param range – The output range of the scale.
- * @param thresholds – The thresholds of the dataset, if supplied manually.
+ * @param params Input parameters to compute thresholds over a GeoJSON FeatureCollection.
+ * @param method The {@link QuantitativeColorScale['type']} to use.
+ * @param layerId The ID of the visualized layer.
+ * @param attribute The data attribute to compute thresholds over.layerId,
+ * @param range The output range of the scale.
+ * @param thresholds The thresholds of the dataset, if supplied manually.
  *
- * @returns – The thresholds of the dataset based on the method, attribute, features, and range supplied.
+ * @returns The thresholds of the range.
  */
 export function deriveThresholds({
   method,

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -2,24 +2,17 @@ import type { SvelteHTMLElements } from 'svelte/elements';
 import type { FeatureCollection } from 'geojson';
 
 /**
- * Represents methods for generating discrete steps in continuous numerical data.
- */
-export type ClassificationMethod =
-  | 'Quantile'
-  | 'Equal Interval'
-  | 'Jenks'
-  | 'Manual';
-
-/**
  * Represents a quantitative D3 color scheme.
  */
 export type QuantitativeColorScheme =
+  // Sequential, single-hue schemes.
   | 'schemeBlues'
   | 'schemeGreens'
   | 'schemeGreys'
   | 'schemeOranges'
   | 'schemePurples'
   | 'schemeReds'
+  // Sequential, multi-hue schemes.
   | 'schemeBuGn'
   | 'schemeBuPu'
   | 'schemeGnBu'
@@ -31,6 +24,7 @@ export type QuantitativeColorScheme =
   | 'schemeYlGn'
   | 'schemeYlOrBr'
   | 'schemeYlOrRd'
+  // Diverging schemes.
   | 'schemeBrBG'
   | 'schemePRGn'
   | 'schemePiYG'
@@ -66,24 +60,182 @@ export type SchemeDirection = 'Forward' | 'Reverse';
 /**
  * Represents a color ramp.
  */
-export type ColorRamp =
-  | 'Cividis'
-  | 'Viridis'
-  | 'Inferno'
-  | 'Magma'
-  | 'Plasma'
-  | 'Warm'
-  | 'Cool'
-  | 'CubehelixDefault'
-  | 'Turbo'
-  | 'Spectral'
-  | 'Rainbow'
-  | 'Sinebow';
+export type QuantitativeColorRamp =
+  // Sequential, single-hue ramps.
+  | 'interpolateBlues'
+  | 'interpolateGreens'
+  | 'interpolateGreys'
+  | 'interpolateOranges'
+  | 'interpolatePurples'
+  | 'interpolateReds'
+  // Sequential, multi-hue ramps.
+  | 'interpolateBuGn'
+  | 'interpolateBuPu'
+  | 'interpolateGnBu'
+  | 'interpolateOrRd'
+  | 'interpolatePuBuGn'
+  | 'interpolatePuBu'
+  | 'interpolatePuRd'
+  | 'interpolateRdPu'
+  | 'interpolateYlGnBu'
+  | 'interpolateYlGn'
+  | 'interpolateYlOrBr'
+  | 'interpolateYlOrRd'
+  | 'interpolateCividis'
+  | 'interpolateViridis'
+  | 'interpolateInferno'
+  | 'interpolateMagma'
+  | 'interpolatePlasma'
+  | 'interpolateWarm'
+  | 'interpolateCool'
+  | 'interpolateCubehelixDefault'
+  | 'interpolateTurbo'
+  // Diverging ramps.
+  | 'interpolateBrBG'
+  | 'interpolatePRGn'
+  | 'interpolatePiYG'
+  | 'interpolatePuOr'
+  | 'interpolateRdBu'
+  | 'interpolateRdGy'
+  | 'interpolateRdYlBu'
+  | 'interpolateRdYlGn'
+  | 'interpolateSpectral'
+  // Cyclical ramps.
+  | 'interpolateRainbow'
+  | 'interpolateSinebow';
 
 /**
  * Represents the direction of a color ramp.
  */
 export type RampDirection = 'Forward' | 'Reverse';
+
+/**
+ * Represents a continuous color scale for continuous numerical data.
+ *
+ * @property type The type of the color scale, 'Continuous'.
+ * @property interpolator.id The {@link QuantitativeColorRamp} identifier for the
+ * color scale.
+ * @property interpolator.direction The {@link RampDirection} of the color scale.
+ */
+export interface ContinuousColorScale {
+  type: 'Continuous';
+  interpolator: {
+    id: QuantitativeColorRamp;
+    direction: RampDirection;
+  };
+}
+
+/**
+ * Represents a quantile color scale that discretizes continuous numerical data
+ * into quantiles.
+ *
+ * @property type The type of the color scale, 'Quantile'.
+ * @property scheme.id The {@link QuantitativeColorScheme} identifier for the
+ * color scale.
+ * @property scheme.direction The {@link SchemeDirection} of the color scale.
+ * @property steps The number of discrete steps (classes) in the color scale.
+ * @property thresholds The thresholds of the color scale.
+ */
+export interface QuantileColorScale {
+  type: 'Quantile';
+  scheme: {
+    id: QuantitativeColorScheme;
+    direction: SchemeDirection;
+  };
+  steps: number;
+  thresholds: number[];
+}
+
+/**
+ * Represents an equal interval (quantize) color scale that discretizes
+ * continuous numerical data into equal intervals.
+ *
+ * @property type The type of the color scale, 'Equal Interval'.
+ * @property scheme.id The {@link QuantitativeColorScheme} identifier for the
+ * color scale.
+ * @property scheme.direction The {@link SchemeDirection} of the color scale.
+ * @property steps The number of discrete steps (classes) in the color scale.
+ * @property thresholds The thresholds of the color scale.
+ */
+export interface EqualIntervalColorScale {
+  type: 'Equal Interval';
+  scheme: {
+    id: QuantitativeColorScheme;
+    direction: SchemeDirection;
+  };
+  steps: number;
+  thresholds: number[];
+}
+
+/**
+ * Represents a Jenks natural breaks color scale that discretizes continuous
+ * numerical data into natural breaks using ckmeans clustering.
+ *
+ * @property type The type of the color scale, 'Jenks'.
+ * @property scheme.id The {@link QuantitativeColorScheme} identifier for the
+ * color scale.
+ * @property scheme.direction The {@link SchemeDirection} of the color scale.
+ * @property steps The number of discrete steps (classes) in the color scale.
+ * @property thresholds The thresholds of the color scale.
+ */
+export interface JenksColorScale {
+  type: 'Jenks';
+  scheme: {
+    id: QuantitativeColorScheme;
+    direction: SchemeDirection;
+  };
+  steps: number;
+  thresholds: number[];
+}
+
+/**
+ * Represents a manual color scale that discretizes continuous numerical data
+ * using user-defined thresholds.
+ *
+ * @property type The type of the color scale, 'Manual'.
+ * @property scheme.id The {@link QuantitativeColorScheme} identifier for the
+ * color scale.
+ * @property scheme.direction The {@link SchemeDirection} of the color scale.
+ * @property steps The number of discrete steps (classes) in the color scale.
+ * @property thresholds The thresholds of the color scale.
+ */
+export interface ManualColorScale {
+  type: 'Manual';
+  scheme: {
+    id: QuantitativeColorScheme;
+    direction: SchemeDirection;
+  };
+  steps: number;
+  thresholds: number[];
+}
+
+/**
+ * Represents the set of possible quantitative color scales.
+ */
+export type QuantitativeColorScale =
+  | ContinuousColorScale
+  | QuantileColorScale
+  | EqualIntervalColorScale
+  | JenksColorScale
+  | ManualColorScale;
+
+/**
+ * Represents a categorical color scale.
+ *
+ * @property type The type of the color scale, 'Categorical'.
+ * @property scheme.id The {@link CategoricalColorScheme} identifier for the
+ * color scale.
+ * @property scheme.direction The {@link SchemeDirection} of the color scale.
+ * @property categories The categories of the color scale.
+ */
+export interface CategoricalColorScale {
+  type: 'Categorical';
+  scheme: {
+    id: CategoricalColorScheme;
+    direction: SchemeDirection;
+  };
+  categories: unknown[];
+}
 
 /**
  * Represents the cartographic form of a layer.
@@ -120,16 +272,16 @@ export type TransformationKind = 'geometric' | 'tabular';
  * Represents a transformation—either internal or user-defined—applied to a
  * layer.
  *
- * @property name - The function name of the transformation.
- * @property params - The function parameters of the transformation.
- * @property paramTypes - The types of the function parameters of the transforma-
+ * @property name The function name of the transformation.
+ * @property params The function parameters of the transformation.
+ * @property paramTypes The types of the function parameters of the transforma-
  * tion.
- * @property returnType - The type of the function return value of the transfor-
+ * @property returnType The type of the function return value of the transfor-
  * mation.
- * @property args - The arguments passed to the transformation.
- * @property definitionTS - The TypeScript function body of the transformation.
- * @property definitionJS - The JavaScript function body of the transformation.
- * @property kind - The kind of the transformation, either geometric or tabular.
+ * @property args The arguments passed to the transformation.
+ * @property definitionTS The TypeScript function body of the transformation.
+ * @property definitionJS The JavaScript function body of the transformation.
+ * @property kind The {@link TransformationKind} of the transformation.
  */
 export interface Transformation {
   name: string;
@@ -154,12 +306,12 @@ export interface TransformationCall extends Transformation {
  *      GeoJSON.
  *   2. The current GeoJSON of the layer, used for display.
  *
- * @property {string} url - The URL of the data source, if fetched from a remote
+ * @property url The URL of the data source, if fetched from a remote
  * server.
- * @property {string} fileName - The name of the data source's file on disk, if
+ * @property fileName The name of the data source's file on disk, if
  * loaded locally.
- * @property {Object} geojson - The current GeoJSON of the layer.
- * @property {Object} sourceGeojson - The source GeoJSON of the layer.
+ * @property geojson The current GeoJSON of the layer.
+ * @property sourceGeojson The source GeoJSON of the layer.
  */
 interface LayerData {
   url?: string;
@@ -172,9 +324,9 @@ interface LayerData {
 /**
  * Represents the layout of a layer.
  *
- * @property {boolean} visible - Whether the layer is visible.
- * @property {number} z - The z-index of the layer.
- * @property {boolean} tooltip.visible - Whether the layer's tooltip is visible.
+ * @property visible Whether the layer is visible.
+ * @property z The z-index of the layer.
+ * @property tooltip.visible Whether the layer's tooltip is visible.
  */
 interface LayerLayout {
   visible: boolean;
@@ -188,12 +340,11 @@ interface LayerLayout {
  * Represents the base structure of a layer in cartokit. All layers extend from
  * this interface.
  *
- * @property {string} id - A globally unique identifier for the layer.
- * @property {string} displayName - A user-supplied display name for the layer.
- * @property {LayerType} type - The type of the layer, @see LayerType.
- * @property {LayerData} data - The data and metadata of the layer, @see
- * LayerData.
- * @property {LayerLayout} layout - The layout of the layer, @see LayerLayout.
+ * @property id A globally unique identifier for the layer.
+ * @property displayName A user-supplied display name for the layer.
+ * @property type The type of the layer, {@link LayerType}.
+ * @property data The data and metadata of the layer, {@link LayerData}.
+ * @property layout The layout of the layer, {@link LayerLayout}.
  */
 interface Layer {
   id: string;
@@ -207,8 +358,8 @@ interface Layer {
  * Represents a Point layer in cartokit. Point layers have a consistent radius,
  * fill, and stroke across all points.
  *
- * @property {'Point'} type - The type of the layer, 'Point'.
- * @property {Object} style - The style of the layer.
+ * @property type The type of the layer, 'Point'.
+ * @property style The style of the layer.
  */
 export interface CartoKitPointLayer extends Layer {
   type: 'Point';
@@ -223,8 +374,8 @@ export interface CartoKitPointLayer extends Layer {
  * Represents a Line layer in cartokit. Line layers have a consistent, required
  * stroke across all lines.
  *
- * @property {'Line'} type - The type of the layer, 'Line'.
- * @property {Object} style - The style of the layer.
+ * @property type The type of the layer, 'Line'.
+ * @property style The style of the layer.
  */
 export interface CartoKitLineLayer extends Layer {
   type: 'Line';
@@ -237,8 +388,8 @@ export interface CartoKitLineLayer extends Layer {
  * Represents a Polygon layer in cartokit. Polygon layers have a consistent fill
  * and stroke across all polygons.
  *
- * @property {'Polygon'} type - The type of the layer, 'Polygon'.
- * @property {Object} style - The style of the layer.
+ * @property type The type of the layer, 'Polygon'.
+ * @property style The style of the layer.
  */
 export interface CartoKitPolygonLayer extends Layer {
   type: 'Polygon';
@@ -253,9 +404,8 @@ export interface CartoKitPolygonLayer extends Layer {
  * ers encode continous numberic data using the size of points, bounded by mini-
  * mum and maximum values.
  *
- * @property {'Proportional Symbol'} type - The type of the layer, 'Proportional
- * Symbol'.
- * @property {Object} style - The style of the layer.
+ * @property type The type of the layer, 'Proportional Symbol'.
+ * @property style The style of the layer.
  */
 export interface CartoKitProportionalSymbolLayer extends Layer {
   type: 'Proportional Symbol';
@@ -271,8 +421,8 @@ export interface CartoKitProportionalSymbolLayer extends Layer {
  * to the color of a region using a classification method. Classification can be
  * either quantitative or categorical.
  *
- * @property {'Choropleth'} type - The type of the layer, 'Choropleth'.
- * @property {Object} style - The style of the layer.
+ * @property type The type of the layer, 'Choropleth'.
+ * @property style The style of the layer.
  */
 export interface CartoKitChoroplethLayer extends Layer {
   type: 'Choropleth';
@@ -287,8 +437,8 @@ export interface CartoKitChoroplethLayer extends Layer {
  * value to a specific number of dots within a region. The size of the dots is
  * constant.
  *
- * @property {'Dot Density'} type - The type of the layer, 'Dot Density'.
- * @property {Object} style - The style of the layer.
+ * @property type The type of the layer, 'Dot Density'.
+ * @property style The style of the layer.
  */
 export interface CartoKitDotDensityLayer extends Layer {
   type: 'Dot Density';
@@ -304,8 +454,8 @@ export interface CartoKitDotDensityLayer extends Layer {
  * Represents a Heatmap layer in cartokit. Heatmap layers map a data value to the
  * color of a region using a color ramp.
  *
- * @property {'Heatmap'} type - The type of the layer, 'Heatmap'.
- * @property {Object} style - The style of the layer.
+ * @property type The type of the layer, 'Heatmap'.
+ * @property style The style of the layer.
  */
 export interface CartoKitHeatmapLayer extends Layer {
   type: 'Heatmap';
@@ -331,9 +481,9 @@ export type CartoKitLayer =
  * Represents a constant style object. A constant style applies a uniform color
  * and opacity to all features in a layer.
  *
- * @property {string} color - The style's color.
- * @property {number} opacity - The style's opacity.
- * @property {boolean} visible - Whether the style is visible.
+ * @property color The style's color.
+ * @property opacity The style's opacity.
+ * @property visible Whether the style is visible.
  */
 export interface ConstantStyle {
   type: 'Constant';
@@ -351,10 +501,10 @@ export type ConstantFill = ConstantStyle;
  * Represents a constant stroke style object. A constant stroke applies a uni-
  * form color, opacity, and stroke-width to all features in a layer.
  *
- * @property {string} color - The style's stroke color.
- * @property {number} opacity - The style's stroke opacity.
- * @property {number} width - The style's stroke width.
- * @property {boolean} visible - Whether the style is visible.
+ * @property color The style's stroke color.
+ * @property opacity The style's stroke opacity.
+ * @property width The style's stroke width.
+ * @property visible Whether the style is visible.
  */
 export interface ConstantStroke extends ConstantStyle {
   width: number;
@@ -363,21 +513,16 @@ export interface ConstantStroke extends ConstantStyle {
 /**
  * Represents a categorical style object.
  *
- * @property {'Categorical'} type - The type of the style object, 'Categorical'.
- * @property {string} attribute - The attribute of the GeoJSON data to classify.
- * @property {string[]} scheme - The color scheme to use,
- * @see CategoricalColorScheme.
- * @property {unknown[]} categories - The categorical values for the attribute.
- * @property {number} opacity - The fill or stroke opacity.
+ * @property type The type of the style object, 'Categorical'.
+ * @property attribute The attribute of the GeoJSON data to classify.
+ * @property scale The {@link CategoricalColorScale} definition.
+ * @property categories The categorical values for the attribute.
+ * @property opacity The fill or stroke opacity.
  */
 export interface CategoricalStyle {
   type: 'Categorical';
   attribute: string;
-  categories: unknown[];
-  scheme: {
-    id: CategoricalColorScheme;
-    direction: SchemeDirection;
-  };
+  scale: CategoricalColorScale;
   opacity: number;
   visible: boolean;
 }
@@ -393,28 +538,16 @@ export type CategoricalFill = CategoricalStyle;
  * of thresholds. Each feature of the map is colored according to the "bin" it
  * falls into.
  *
- * @property {'Quantitative'} type - The type of the fill style, 'Quantitative'.
- * @property {string} attribute - The attribute of the GeoJSON data to classify.
- * @property {string} method - The classification method to use, @see
- * ClassificationMethod.
- * @property {string[][]} scheme - The color scheme to use, @see
- * QuantitativeColorScheme.
- * @property {number} count - The number of thresholds.
- * @property {number[]} thresholds - The thresholds generated by the classifi-
- * cation method from the data.
- * @property {number} opacity - The fill or stroke opacity.
- * @property {boolean} visible - Whether the style is visible.
+ * @property type The type of the fill style, 'Quantitative'.
+ * @property attribute The attribute of the GeoJSON data to visualize.
+ * @property scale The {@link QuantitativeColorScale} definition.
+ * @property opacity The opacity of the style.
+ * @property visible The visibility of the style.
  */
 export interface QuantitativeStyle {
   type: 'Quantitative';
   attribute: string;
-  method: ClassificationMethod;
-  scheme: {
-    id: QuantitativeColorScheme;
-    direction: SchemeDirection;
-  };
-  count: number;
-  thresholds: number[];
+  scale: QuantitativeColorScale;
   opacity: number;
   visible: boolean;
 }
@@ -429,10 +562,10 @@ export type QuantitativeFill = QuantitativeStyle;
  * size style object specifies the attribute of the GeoJSON data to map to the
  * size of each point, bounded by minimum and maximum values.
  *
- * @property {string} attribute - The attribute of the GeoJSON data to map to
+ * @property attribute The attribute of the GeoJSON data to map to
  * the size of the points.
- * @property {number} min - The minimum size of the points.
- * @property {number} max - The maximum size of the points.
+ * @property min The minimum size of the points.
+ * @property max The maximum size of the points.
  */
 interface ProportionalSymbolStyle {
   attribute: string;
@@ -445,10 +578,10 @@ interface ProportionalSymbolStyle {
  * specifies the attribute of the GeoJSON data to divide by the dot value of the
  * layer to produce a discrete number of dots. The size of the dots is constant.
  *
- * @property {string} attribute - The attribute of the GeoJSON data to map to
+ * @property attribute The attribute of the GeoJSON data to map to
  * the number of dots.
- * @property {number} size - The size of the dots.
- * @property {number} value - The dot value, representing the ratio of source
+ * @property size The size of the dots.
+ * @property value The dot value, representing the ratio of source
  * data units to number of dots.
  */
 export interface DotDensityStyle {
@@ -459,7 +592,7 @@ export interface DotDensityStyle {
 /**
  * Represents a constant heatmap weight style object.
  *
- * @property {number} value - The weight of the heatmap.
+ * @property value The weight of the heatmap.
  */
 export interface ConstantHeatmapWeight {
   type: 'Constant';
@@ -469,10 +602,10 @@ export interface ConstantHeatmapWeight {
 /**
  * Represents a quantitative heatmap weight style object.
  *
- * @property {string} attribute - The attribute of the GeoJSON data to map to the
+ * @property attribute The attribute of the GeoJSON data to map to the
  * weight of the heatmap.
- * @property {number} min - The minimum weight of the heatmap.
- * @property {number} max - The maximum weight of the heatmap.
+ * @property min The minimum weight of the heatmap.
+ * @property max The maximum weight of the heatmap.
  */
 export interface QuantitativeHeatmapWeight {
   type: 'Quantitative';
@@ -484,18 +617,17 @@ export interface QuantitativeHeatmapWeight {
 /**
  * Represents the display style of a heatmap layer.
  *
- * @property {ConstantHeatmapWeight | QuantitativeHeatmapWeight} weight - The
- * weight of the heatmap.
- * @property {ColorRamp} ramp - The color ramp to use for the heatmap.
- * @property {number} radius - The radius of the heatmap.
- * @property {number} intensity - The intensity of the heatmap.
- * @property {number} opacity - The opacity of the heatmap.
- * @property {boolean} visible - Whether the style is visible.
+ * @property weight The weight of the heatmap.
+ * @property ramp The color ramp to use for the heatmap.
+ * @property radius The radius of the heatmap.
+ * @property intensity The intensity of the heatmap.
+ * @property opacity The opacity of the heatmap.
+ * @property visible Whether the style is visible.
  */
 export interface HeatmapStyle {
   weight: ConstantHeatmapWeight | QuantitativeHeatmapWeight;
   ramp: {
-    id: ColorRamp;
+    id: QuantitativeColorRamp;
     direction: RampDirection;
   };
   radius: number;
@@ -506,11 +638,10 @@ export interface HeatmapStyle {
 /**
  * Represents a basemap in cartokit.
  *
- * @property {string} title - The name of the basemap, set by the tile provider.
- * @property {string} tileId - The tile ID of the basemap, set by the tile pro-
+ * @property title The name of the basemap, set by the tile provider.
+ * @property tileId The tile ID of the basemap, set by the tile pro-
  * vider.
- * @property {EnhancedImgAttributes['src']} src - The source for the basemap
- * thumbnail.
+ * @property src The source for the basemap thumbnail.
  */
 export interface Basemap {
   title: string;

--- a/src/lib/utils/classification.ts
+++ b/src/lib/utils/classification.ts
@@ -1,6 +1,7 @@
-import type { ClassificationMethod } from '$lib/types';
+import type { QuantitativeColorScale } from '$lib/types';
 
-export const CLASSIFICATION_METHODS: ClassificationMethod[] = [
+export const CLASSIFICATION_METHODS: QuantitativeColorScale['type'][] = [
+  'Continuous',
   'Quantile',
   'Equal Interval',
   'Jenks',

--- a/src/lib/utils/color/converter.spec.ts
+++ b/src/lib/utils/color/converter.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test, describe } from 'vitest';
+
+import {
+  convertSchemeToRamp,
+  convertRampToScheme
+} from '$lib/utils/color/converter';
+import { DEFAULT_QUANTITATIVE_SCHEME } from '$lib/utils/constants';
+
+describe('convertSchemeToRamp', () => {
+  test('converts a valid sequential single-hue scheme to its ramp', () => {
+    expect(convertSchemeToRamp('schemeBlues')).toBe('interpolateBlues');
+  });
+
+  test('converts a valid sequential multi-hue scheme to its ramp', () => {
+    expect(convertSchemeToRamp('schemeBuGn')).toBe('interpolateBuGn');
+  });
+
+  test('converts a valid diverging scheme to its ramp', () => {
+    expect(convertSchemeToRamp('schemeSpectral')).toBe('interpolateSpectral');
+  });
+});
+
+describe('convertRampToScheme', () => {
+  test('converts a valid sequential single-hue ramp to its scheme', () => {
+    expect(convertRampToScheme('interpolateBlues')).toBe('schemeBlues');
+  });
+
+  test('converts a valid sequential multi-hue ramp to its scheme', () => {
+    expect(convertRampToScheme('interpolateBuGn')).toBe('schemeBuGn');
+  });
+
+  test('converts a valid diverging ramp to its scheme', () => {
+    expect(convertRampToScheme('interpolateSpectral')).toBe('schemeSpectral');
+  });
+
+  test('returns DEFAULT_QUANTITATIVE_SCHEME when the ramp has no corresponding scheme', () => {
+    // 'interpolateViridis' -> 'schemeViridis', which is not a valid scheme.
+    expect(convertRampToScheme('interpolateViridis')).toBe(
+      DEFAULT_QUANTITATIVE_SCHEME
+    );
+  });
+
+  test('returns DEFAULT_QUANTITATIVE_SCHEME when the ramp has no corresponding scheme (cyclical)', () => {
+    // 'interpolateRainbow' -> 'schemeRainbow', which is not a valid scheme.
+    expect(convertRampToScheme('interpolateRainbow')).toBe(
+      DEFAULT_QUANTITATIVE_SCHEME
+    );
+  });
+});

--- a/src/lib/utils/color/converter.ts
+++ b/src/lib/utils/color/converter.ts
@@ -14,7 +14,6 @@ import { DEFAULT_QUANTITATIVE_SCHEME } from '$lib/utils/constants';
 export function convertSchemeToRamp(
   scheme: QuantitativeColorScheme
 ): QuantitativeColorRamp {
-  // All D3 schemes have valid interpolator equivalents.
   return scheme.replace('scheme', 'interpolate') as QuantitativeColorRamp;
 }
 

--- a/src/lib/utils/color/converter.ts
+++ b/src/lib/utils/color/converter.ts
@@ -1,0 +1,37 @@
+import type {
+  QuantitativeColorScheme,
+  QuantitativeColorRamp
+} from '$lib/types';
+import { QUANTITATIVE_COLOR_SCHEMES } from '$lib/utils/color/scheme';
+import { DEFAULT_QUANTITATIVE_SCHEME } from '$lib/utils/constants';
+
+/**
+ * Convert a {@link QuantitativeColorScheme} to a {@link QuantitativeColorRamp}.
+ *
+ * @param scheme The {@link QuantitativeColorScheme} to convert.
+ * @returns The {@link QuantitativeColorRamp} equivalent.
+ */
+export function convertSchemeToRamp(
+  scheme: QuantitativeColorScheme
+): QuantitativeColorRamp {
+  // All D3 schemes have valid interpolator equivalents.
+  return scheme.replace('scheme', 'interpolate') as QuantitativeColorRamp;
+}
+
+/**
+ * Convert a {@link QuantitativeColorRamp} to a {@link QuantitativeColorScheme}.
+ *
+ * @param ramp The {@link QuantitativeColorRamp} to convert.
+ * @returns The {@link QuantitativeColorScheme} equivalent.
+ */
+export function convertRampToScheme(
+  ramp: QuantitativeColorRamp
+): QuantitativeColorScheme {
+  const id = ramp.replace('interpolate', 'scheme');
+
+  if (QUANTITATIVE_COLOR_SCHEMES.includes(id as QuantitativeColorScheme)) {
+    return id as QuantitativeColorScheme;
+  }
+
+  return DEFAULT_QUANTITATIVE_SCHEME;
+}

--- a/src/lib/utils/color/ramp.ts
+++ b/src/lib/utils/color/ramp.ts
@@ -1,20 +1,50 @@
 import * as d3 from 'd3';
 
-import type { ColorRamp, RampDirection } from '$lib/types';
+import type { QuantitativeColorRamp, RampDirection } from '$lib/types';
 
-export const COLOR_RAMPS: ColorRamp[] = [
-  'Cividis',
-  'Viridis',
-  'Inferno',
-  'Magma',
-  'Plasma',
-  'Warm',
-  'Cool',
-  'CubehelixDefault',
-  'Turbo',
-  'Spectral',
-  'Rainbow',
-  'Sinebow'
+export const QUANTITATIVE_COLOR_RAMPS: QuantitativeColorRamp[] = [
+  // Sequential, single-hue ramps.
+  'interpolateBlues',
+  'interpolateGreens',
+  'interpolateGreys',
+  'interpolateOranges',
+  'interpolatePurples',
+  'interpolateReds',
+  // Sequential, multi-hue ramps.
+  'interpolateBuGn',
+  'interpolateBuPu',
+  'interpolateGnBu',
+  'interpolateOrRd',
+  'interpolatePuBuGn',
+  'interpolatePuBu',
+  'interpolatePuRd',
+  'interpolateRdPu',
+  'interpolateYlGnBu',
+  'interpolateYlGn',
+  'interpolateYlOrBr',
+  'interpolateYlOrRd',
+  'interpolateCividis',
+  'interpolateViridis',
+  'interpolateInferno',
+  'interpolateMagma',
+  'interpolatePlasma',
+  'interpolateWarm',
+  'interpolateCool',
+  'interpolateCubehelixDefault',
+  'interpolateTurbo',
+  // Diverging ramps.
+  'interpolateBrBG',
+  'interpolatePRGn',
+  'interpolatePiYG',
+  'interpolatePuOr',
+  'interpolateRdBu',
+  'interpolateRdGy',
+  'interpolateRdYlBu',
+  'interpolateRdYlGn',
+  'interpolateSpectral',
+  // Cyclical ramps.
+  'interpolateRainbow',
+  'interpolateSinebow'
 ];
 
 /**
@@ -26,11 +56,11 @@ export const COLOR_RAMPS: ColorRamp[] = [
  * @returns An array of colors in hexadecimal format.
  */
 export function materializeColorRamp(
-  ramp: ColorRamp,
+  ramp: QuantitativeColorRamp,
   rampDirection: RampDirection,
   n = 256
 ): string[] {
-  const interpolate = d3[`interpolate${ramp}`];
+  const interpolate = d3[ramp];
   const colors: string[] = [];
 
   for (let i = 0; i <= n; i++) {

--- a/src/lib/utils/constants.ts
+++ b/src/lib/utils/constants.ts
@@ -10,7 +10,7 @@ export const DEFAULT_STROKE_OPACITY = 1;
 export const DEFAULT_METHOD = 'Quantile';
 export const DEFAULT_QUANTITATIVE_SCHEME = 'schemeOranges';
 export const DEFAULT_CATEGORICAL_SCHEME = 'schemeCategory10';
-export const DEFAULT_RAMP = 'Spectral';
+export const DEFAULT_RAMP = 'interpolateSpectral';
 export const DEFAULT_SCHEME_DIRECTION = 'Forward';
 export const DEFAULT_COUNT = 5;
 export const DEFAULT_THRESHOLDS = (layerId: string, attribute: string) =>

--- a/src/routes/llm/+server.ts
+++ b/src/routes/llm/+server.ts
@@ -222,6 +222,67 @@ function FillColorSchemeDirectionDiff(
   });
 }
 
+const QuantitativeColorRamp = z.union([
+  z.literal('interpolateBlues'),
+  z.literal('interpolateGreens'),
+  z.literal('interpolateGreys'),
+  z.literal('interpolateOranges'),
+  z.literal('interpolatePurples'),
+  z.literal('interpolateReds'),
+  z.literal('interpolateBuGn'),
+  z.literal('interpolateBuPu'),
+  z.literal('interpolateGnBu'),
+  z.literal('interpolateOrRd'),
+  z.literal('interpolatePuBuGn'),
+  z.literal('interpolatePuBu'),
+  z.literal('interpolatePuRd'),
+  z.literal('interpolateRdPu'),
+  z.literal('interpolateYlGnBu'),
+  z.literal('interpolateYlGn'),
+  z.literal('interpolateYlOrBr'),
+  z.literal('interpolateYlOrRd'),
+  z.literal('interpolateCividis'),
+  z.literal('interpolateViridis'),
+  z.literal('interpolateInferno'),
+  z.literal('interpolateMagma'),
+  z.literal('interpolatePlasma'),
+  z.literal('interpolateWarm'),
+  z.literal('interpolateCool'),
+  z.literal('interpolateCubehelixDefault'),
+  z.literal('interpolateTurbo'),
+  z.literal('interpolateBrBG'),
+  z.literal('interpolatePRGn'),
+  z.literal('interpolatePiYG'),
+  z.literal('interpolatePuOr'),
+  z.literal('interpolateRdBu'),
+  z.literal('interpolateRdGy'),
+  z.literal('interpolateRdYlBu'),
+  z.literal('interpolateRdYlGn'),
+  z.literal('interpolateSpectral'),
+  z.literal('interpolateRainbow'),
+  z.literal('interpolateSinebow')
+]);
+
+function FillColorRampDiff(layerIdSchema: z.infer<typeof makeLayerIdSchema>) {
+  return z.object({
+    type: z.literal('fill-color-ramp'),
+    layerId: layerIdSchema,
+    payload: z.object({ ramp: QuantitativeColorRamp })
+  });
+}
+
+function FillColorRampDirectionDiff(
+  layerIdSchema: z.infer<typeof makeLayerIdSchema>
+) {
+  return z.object({
+    type: z.literal('fill-color-ramp-direction'),
+    layerId: layerIdSchema,
+    payload: z.object({
+      direction: z.union([z.literal('Forward'), z.literal('Reverse')])
+    })
+  });
+}
+
 const ClassificationMethod = z.union([
   z.literal('Quantile'),
   z.literal('Equal Interval'),
@@ -630,6 +691,8 @@ function makeSchema(
         FillColorDiff(layerIdSchema),
         FillColorSchemeDiff(layerIdSchema),
         FillColorSchemeDirectionDiff(layerIdSchema),
+        FillColorRampDiff(layerIdSchema),
+        FillColorRampDirectionDiff(layerIdSchema),
         FillClassificationMethodDiff(layerIdSchema),
         FillStepCountDiff(layerIdSchema),
         FillStepValueDiff(layerIdSchema),

--- a/src/routes/llm/+server.ts
+++ b/src/routes/llm/+server.ts
@@ -619,7 +619,9 @@ function RemoveLayerDiff(layerIdSchema: z.infer<typeof makeLayerIdSchema>) {
   return z.object({
     type: z.literal('remove-layer'),
     layerId: layerIdSchema,
-    payload: z.object({})
+    payload: z.object({
+      sourceLayerType: LayerType
+    })
   });
 }
 

--- a/tests/components/color-scales.spec.ts
+++ b/tests/components/color-scales.spec.ts
@@ -229,4 +229,41 @@ test.describe('color scales', () => {
     firstRect = page.getByTestId('choropleth-legend').locator('rect').first();
     await expect(firstRect).toHaveAttribute('fill', d3.schemeOranges[5][0]);
   });
+
+  test('supports changing from Continuous to Quantile', async ({ page }) => {
+    // Switch to Continuous first.
+    await page.locator('#fill-classification-method-select').selectOption('Continuous');
+    await expect(page.locator('#fill-classification-method-select')).toHaveValue('Continuous');
+
+    // Switch back to Quantile.
+    await page.locator('#fill-classification-method-select').selectOption('Quantile');
+    await expect(page.locator('#fill-classification-method-select')).toHaveValue('Quantile');
+
+    const quantiles = [-1528.88, -77.05, 4, 25.89, 71.08, 608.88];
+
+    // Assert values in the legend.
+    for (const quantile of quantiles) {
+      await expect(page.getByTestId('choropleth-legend')).toContainText(
+        quantile.toString()
+      );
+    }
+  });
+
+test('supports changing from Quantile to Continuous', async ({ page }) => {
+  // Switch to Quantile first.
+    await page.locator('#fill-classification-method-select').selectOption('Quantile');
+    await expect(page.locator('#fill-classification-method-select')).toHaveValue('Quantile');
+
+    // Switch back to Continuous.
+    await page.locator('#fill-classification-method-select').selectOption('Continuous');
+    await expect(page.locator('#fill-classification-method-select')).toHaveValue('Continuous');
+
+    // Assert values in the legend.
+    await expect(page.getByTestId('choropleth-legend')).toContainText('-1528.88');
+    await expect(page.getByTestId('choropleth-legend')).toContainText('608.88');
+
+    // No intermediate values.
+    await expect(page.getByTestId('choropleth-legend')).not.toContainText('25.89');
+  });
+
 });

--- a/tests/components/color-scales.spec.ts
+++ b/tests/components/color-scales.spec.ts
@@ -232,12 +232,20 @@ test.describe('color scales', () => {
 
   test('supports changing from Continuous to Quantile', async ({ page }) => {
     // Switch to Continuous first.
-    await page.locator('#fill-classification-method-select').selectOption('Continuous');
-    await expect(page.locator('#fill-classification-method-select')).toHaveValue('Continuous');
+    await page
+      .locator('#fill-classification-method-select')
+      .selectOption('Continuous');
+    await expect(
+      page.locator('#fill-classification-method-select')
+    ).toHaveValue('Continuous');
 
     // Switch back to Quantile.
-    await page.locator('#fill-classification-method-select').selectOption('Quantile');
-    await expect(page.locator('#fill-classification-method-select')).toHaveValue('Quantile');
+    await page
+      .locator('#fill-classification-method-select')
+      .selectOption('Quantile');
+    await expect(
+      page.locator('#fill-classification-method-select')
+    ).toHaveValue('Quantile');
 
     const quantiles = [-1528.88, -77.05, 4, 25.89, 71.08, 608.88];
 
@@ -249,21 +257,32 @@ test.describe('color scales', () => {
     }
   });
 
-test('supports changing from Quantile to Continuous', async ({ page }) => {
-  // Switch to Quantile first.
-    await page.locator('#fill-classification-method-select').selectOption('Quantile');
-    await expect(page.locator('#fill-classification-method-select')).toHaveValue('Quantile');
+  test('supports changing from Quantile to Continuous', async ({ page }) => {
+    // Switch to Quantile first.
+    await page
+      .locator('#fill-classification-method-select')
+      .selectOption('Quantile');
+    await expect(
+      page.locator('#fill-classification-method-select')
+    ).toHaveValue('Quantile');
 
     // Switch back to Continuous.
-    await page.locator('#fill-classification-method-select').selectOption('Continuous');
-    await expect(page.locator('#fill-classification-method-select')).toHaveValue('Continuous');
+    await page
+      .locator('#fill-classification-method-select')
+      .selectOption('Continuous');
+    await expect(
+      page.locator('#fill-classification-method-select')
+    ).toHaveValue('Continuous');
 
     // Assert values in the legend.
-    await expect(page.getByTestId('choropleth-legend')).toContainText('-1528.88');
+    await expect(page.getByTestId('choropleth-legend')).toContainText(
+      '-1528.88'
+    );
     await expect(page.getByTestId('choropleth-legend')).toContainText('608.88');
 
     // No intermediate values.
-    await expect(page.getByTestId('choropleth-legend')).not.toContainText('25.89');
+    await expect(page.getByTestId('choropleth-legend')).not.toContainText(
+      '25.89'
+    );
   });
-
 });

--- a/tests/components/color-scales.spec.ts
+++ b/tests/components/color-scales.spec.ts
@@ -1,0 +1,232 @@
+import { test, expect } from '@playwright/test';
+import * as d3 from 'd3';
+
+test.describe('color scales', () => {
+  test.beforeEach(async ({ page }) => {
+    // Navigate to cartokit, running on a local development server.
+    await page.goto('/');
+
+    if (page.url().includes('vercel.app')) {
+      // In Preview Vercel environments, ensure <vercel-live-feedback> does not
+      // intercept pointer events.
+      await page.locator('vercel-live-feedback').waitFor({ state: 'attached' });
+      await page.locator('vercel-live-feedback').evaluate((element) => {
+        element.style.pointerEvents = 'none';
+        element.style.zIndex = '-1';
+        element.style.display = 'none';
+      });
+    }
+
+    // Wait for the Open Editor button and Add Layer button to become enabled.
+    // These are proxies for the map reaching an idle state.
+    await expect(page.getByTestId('editor-toggle')).toBeEnabled({
+      timeout: 10000
+    });
+    await expect(page.getByTestId('add-layer-button')).toBeEnabled({
+      timeout: 10000
+    });
+
+    // Open the Add Layer modal.
+    await page.getByTestId('add-layer-button').click();
+    await expect(page.getByTestId('add-layer-modal')).toBeVisible();
+
+    // Select the From Gallery tab.
+    await page.getByRole('button', { name: 'From Gallery' }).click();
+
+    // Select the Climate Impact Regions dataset. The modal closes automatically
+    // once the MapLibre source finishes loading.
+    await page.getByRole('button', { name: 'Climate Impact Regions' }).click();
+
+    // Ensure the Add Layer modal is no longer visible.
+    await expect(page.getByTestId('add-layer-modal')).not.toBeVisible();
+
+    // Wait for MapLibre to render the Climate Impact Regions layer.
+    //
+    // Tiles are generated on the fly by MapLibre, so we need to wait for them
+    // to load. In theory, we'd like to hook into MapLibre's event system to
+    // determine when the map is idle; however, we don't want to attach the map
+    // instance to the global window object just for the sake of testing.
+    await page.waitForTimeout(5000);
+
+    // Click on the layer entry in the Layers Panel.
+    await page.getByTestId('layer-entry').first().click();
+
+    // Ensure the Properties Panel is visible.
+    await expect(page.locator('#properties')).toBeVisible();
+
+    // Remove the layer's stroke.
+    await page.getByTestId('remove-stroke-button').click();
+
+    // Switch the layer's type to Choropleth.
+    await page.locator('#layer-type-select').selectOption('Choropleth');
+
+    // Set the layer's Attribute to 'years_2080_2099'.
+    await page
+      .locator('#fill-attribute-select')
+      .selectOption('years_2080_2099');
+  });
+
+  test('supports the Quantile classification method', async ({ page }) => {
+    // Quantile is the default method; verify it is selected.
+    await expect(
+      page.locator('#fill-classification-method-select')
+    ).toHaveValue('Quantile');
+
+    const quantiles = [-1528.88, -77.05, 4, 25.89, 71.08, 608.88];
+
+    // Assert values in the Legend.
+    for (const quantile of quantiles) {
+      await expect(page.getByTestId('choropleth-legend')).toContainText(
+        quantile.toString()
+      );
+    }
+  });
+
+  test('supports the Equal Interval classification method', async ({
+    page
+  }) => {
+    await page
+      .locator('#fill-classification-method-select')
+      .selectOption('Equal Interval');
+
+    await expect(
+      page.locator('#fill-classification-method-select')
+    ).toHaveValue('Equal Interval');
+
+    const intervals = [-1528.88, -1101.33, -673.78, -246.22, 181.33, 608.88];
+
+    // Assert values in the Legend.
+    for (const interval of intervals) {
+      await expect(page.getByTestId('choropleth-legend')).toContainText(
+        interval.toString()
+      );
+    }
+  });
+
+  test('supports the Jenks classification method', async ({ page }) => {
+    await page
+      .locator('#fill-classification-method-select')
+      .selectOption('Jenks');
+
+    await expect(
+      page.locator('#fill-classification-method-select')
+    ).toHaveValue('Jenks');
+
+    const breaks = [-1528.88, -653.58, -256.85, -40.91, 146.09, 608.88];
+
+    // Assert values in the Legend.
+    for (const brk of breaks) {
+      await expect(page.getByTestId('choropleth-legend')).toContainText(
+        brk.toString()
+      );
+    }
+  });
+
+  test('supports the Manual classification method with custom breaks', async ({
+    page
+  }) => {
+    await page
+      .locator('#fill-classification-method-select')
+      .selectOption('Manual');
+
+    // Verify the breaks editor dialog is visible.
+    await expect(page.getByTestId('breaks-editor')).toBeVisible();
+
+    // Set custom breaks.
+    const stops = [-400, -200, 0, 200];
+    let i = 0;
+
+    for await (const stop of stops) {
+      const input = page
+        .getByTestId('breaks-editor')
+        .locator('input:last-child')
+        .nth(i);
+
+      await input.fill(stop.toString());
+      await input.press('Enter');
+      i++;
+    }
+
+    // Assert values in the Legend.
+    for (const stop of stops) {
+      await expect(page.getByTestId('choropleth-legend')).toContainText(
+        stop.toString()
+      );
+    }
+
+    // Verify the breaks editor is still visible after updating breaks.
+    await expect(page.getByTestId('breaks-editor')).toBeVisible();
+  });
+
+  test('supports changing the step count', async ({ page }) => {
+    // Increase the step count to 9.
+    await page.locator('#fill-step-count-select').selectOption('9');
+
+    await expect(page.locator('#fill-step-count-select')).toHaveValue('9');
+
+    // Assert values in the Legend.
+    const deciles = [
+      -1528.88, -148.83, -60.8, -7.48, 8.89, 21.08, 33.83, 62.79, 105.7, 608.88
+    ];
+
+    for (const decile of deciles) {
+      await expect(page.getByTestId('choropleth-legend')).toContainText(
+        decile.toString()
+      );
+    }
+
+    // Decrease the step count to 3.
+    await page.locator('#fill-step-count-select').selectOption('3');
+
+    await expect(page.locator('#fill-step-count-select')).toHaveValue('3');
+
+    // Assert values in the Legend.
+    const terciles = [-1528.88, -7.48, 33.83, 608.88];
+
+    for (const tercile of terciles) {
+      await expect(page.getByTestId('choropleth-legend')).toContainText(
+        tercile.toString()
+      );
+    }
+  });
+
+  test('supports changing the color scheme', async ({ page }) => {
+    // Switch the color scheme to BrBG (li:nth-child(19)).
+    await page.locator('#color-scheme').getByRole('button').click();
+    await page.locator('li:nth-child(19)').getByRole('button').click();
+
+    // Assert a particular color for the first rectangle in the Legend.
+    let firstRect = page
+      .getByTestId('choropleth-legend')
+      .locator('rect')
+      .first();
+    await expect(firstRect).toHaveAttribute('fill', d3.schemeBrBG[5][0]);
+
+    // Switch the color scheme to Spectral (li:nth-child(27)).
+    await page.locator('#color-scheme').getByRole('button').click();
+    await page.locator('li:nth-child(27)').getByRole('button').click();
+
+    // Assert a particular color for the first rectangle in the Legend.
+    firstRect = page.getByTestId('choropleth-legend').locator('rect').first();
+    await expect(firstRect).toHaveAttribute('fill', d3.schemeSpectral[5][0]);
+  });
+
+  test('supports reversing the color scheme direction', async ({ page }) => {
+    // Reverse the default (Forward) color scheme.
+    await page.getByTestId('color-scheme-reverse-button').click();
+
+    // Assert a particular color for the first rectangle in the Legend.
+    let firstRect = page
+      .getByTestId('choropleth-legend')
+      .locator('rect')
+      .first();
+    await expect(firstRect).toHaveAttribute('fill', d3.schemeOranges[5][4]);
+
+    // Reverse it back to Forward.
+    await page.getByTestId('color-scheme-reverse-button').click();
+
+    // Assert a particular color for the first rectangle in the Legend.
+    firstRect = page.getByTestId('choropleth-legend').locator('rect').first();
+    await expect(firstRect).toHaveAttribute('fill', d3.schemeOranges[5][0]);
+  });
+});


### PR DESCRIPTION
This PR is a second effort on #1558 after we learned how that modeling strategy was going to shake out. The key choice here is to introduce a `scale` property on the IR for `fill` channel, which can be one of:

```typescript
type QuantitativeColorScale =
  | ContinuousColorScale
  | QuantileColorScale
  | EqualIntervalColorScale
  | JenksColorScale
  | ManualColorScale;

// Or, for categorical data...
interface CategoricalColorScale {
  type: 'Categorical';
  scheme: {
    id: CategoricalColorScheme;
    direction: SchemeDirection;
  };
  categories: unknown[];
}
```

From a structural perspective, this keeps all parameters that influence the scale under one object, which can be discriminated on via the `type` key. In a lot of ways, it's a much closer approximation of the D3 API, but still high-level enough to stay closely scoped to our cartographic use cases. Eventually, we may just embrace the full D3 / Vega-Lite strategy for all channels, but that's a larger refactor.

## Path to Completion

cc/ @arfamomin, here are the things that still need to happen.

- [x] I've marked all of the actual adjustments we need to make with TODO across the codebase, so please tackle those (and just DM me if they're unclear).
- [x] Add diffs for `'fill-color-ramp'` and `'fill-color-ramp-direction'`, adjusting both `src/lib/core/diff/index.ts` and `src/routes/llm/+server.ts'.
- [x] Implement patch-recon for the above diffs; it should be basically identical to what you did in #1558
- [x] Please add back your `ColorInterpolatorSelect` component, with two minor modifications:
  1. Change the name to `ColorRampSelect`
  2. Parameterize the component so that it will accept a `channel` prop of type `'heatmap-color' | 'fill-color'` and, based on this prop, dispatch the correct diffs for updating both the color ramp and color ramp direction in the associated callbacks. While you're here, remove the `HeatmapColor.svelte` component and swap out its use with `ColorRampSelect.svelte`.
- [x] Extend `color-scales.spec.ts` with two Playwright tests that exercise changing from 'Continuous' to 'Quantile' and 'Quantile' to 'Continuous', respectively.
- [x] Fix any bugs I most assuredly introduced 😂 