### PR TITLE
feat: Initial scaffolding for dark mode.

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1,5 +1,7 @@
 @import 'tailwindcss';
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 @theme {
   /* Font Size */
   --text-2xs: 0.6875rem;

--- a/src/lib/components/chat/ChatButton.svelte
+++ b/src/lib/components/chat/ChatButton.svelte
@@ -1,11 +1,21 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
+
   import { onClickOutside } from '$lib/attachments/on-click-outside';
+  import { tooltip } from '$lib/attachments/tooltip';
   import Chat from '$lib/components/chat/Chat.svelte';
   import ChatIcon from '$lib/components/icons/ChatIcon.svelte';
+  import { registerKeybinding } from '$lib/utils/keybinding';
 
   let chatVisible = $state(false);
   let requestInFlight = $state(false);
   let form: HTMLFormElement | undefined = $state();
+
+  onMount(() => {
+    const deregisterKeybinding = registerKeybinding('c', onClick);
+
+    return deregisterKeybinding;
+  });
 
   function onClick() {
     chatVisible = true;
@@ -31,6 +41,7 @@
     }
   ]}
   {@attach onClickOutside({ callback: onClickOutsideChat })}
+  {@attach tooltip({ content: 'Chat', keybinding: 'C' })}
 >
   <ChatIcon />
 </button>

--- a/src/lib/components/layers/FromAPI.svelte
+++ b/src/lib/components/layers/FromAPI.svelte
@@ -69,6 +69,9 @@
       });
 
       map.value!.on('sourcedata', handleSourceLoaded(layerId));
+
+      endpoint = '';
+      displayName = '';
     } catch (e) {
       error =
         e instanceof Error

--- a/src/lib/components/layers/FromFile.svelte
+++ b/src/lib/components/layers/FromFile.svelte
@@ -70,6 +70,8 @@
             }
           });
 
+          displayName = '';
+          file = null;
           closeModal();
         } catch (e) {
           error =

--- a/src/lib/components/legends/PointLegend.svelte
+++ b/src/lib/components/legends/PointLegend.svelte
@@ -22,7 +22,7 @@
   let attrs = $derived(
     layer.style.fill.type === 'Constant'
       ? {
-          fill: layer.style.fill.color,
+          fill: layer.style.fill.visible ? layer.style.fill.color : 'none',
           'fill-opacity': layer.style.fill.visible
             ? layer.style.fill.opacity
             : 0,

--- a/src/lib/components/legends/PointLegend.svelte
+++ b/src/lib/components/legends/PointLegend.svelte
@@ -23,7 +23,9 @@
     layer.style.fill.type === 'Constant'
       ? {
           fill: layer.style.fill.color,
-          'fill-opacity': layer.style.fill.opacity ?? 0,
+          'fill-opacity': layer.style.fill.visible
+            ? layer.style.fill.opacity
+            : 0,
           stroke: layer.style.stroke.visible
             ? layer.style.stroke.color
             : 'none',

--- a/src/lib/components/map/BasemapGrid.svelte
+++ b/src/lib/components/map/BasemapGrid.svelte
@@ -6,7 +6,7 @@
   import TextInput from '$lib/components/shared/TextInput.svelte';
   import { applyDiff, type CartoKitDiff } from '$lib/core/diff';
   import { ir } from '$lib/stores/ir';
-  import type { BasemapProvider } from '$lib/types';
+  import type { BasemapProvider, ThemeMode } from '$lib/types';
   import { BASEMAPS, TILE_URLS } from '$lib/utils/basemap';
 
   interface Props {
@@ -26,13 +26,14 @@
     tileUrl = event.currentTarget.value;
   }
 
-  function onSelectBasemap(tileUrl: string) {
+  function onSelectBasemap(tileUrl: string, mode: ThemeMode) {
     return async function updateBasemap() {
       const diff: CartoKitDiff = {
         type: 'basemap',
         payload: {
           url: tileUrl,
-          provider: provider
+          provider,
+          mode
         }
       };
 
@@ -56,7 +57,7 @@
       />
     </div>
     <Button
-      onclick={onSelectBasemap(tileUrl)}
+      onclick={onSelectBasemap(tileUrl, 'light')}
       class="mt-2 self-end"
       disabled={!tileUrl || tileUrl === $ir.basemap.url}>Apply</Button
     >
@@ -71,7 +72,10 @@
             ? 'border-slate-400'
             : 'border-transparent'
         ]}
-        onclick={onSelectBasemap(TILE_URLS[provider](basemap.tileId))}
+        onclick={onSelectBasemap(
+          TILE_URLS[provider](basemap.tileId),
+          basemap.mode
+        )}
       >
         <enhanced:img
           src={basemap.src}

--- a/src/lib/components/map/CustomTiles.svelte
+++ b/src/lib/components/map/CustomTiles.svelte
@@ -24,7 +24,8 @@
       type: 'basemap',
       payload: {
         url: tileUrl,
-        provider: 'Custom'
+        provider: 'Custom',
+        mode: 'light'
       }
     };
 

--- a/src/lib/components/shared/FileInput.svelte
+++ b/src/lib/components/shared/FileInput.svelte
@@ -20,6 +20,12 @@
       files = null;
     }
   });
+
+  function onClick(
+    event: MouseEvent & { currentTarget: EventTarget & HTMLInputElement }
+  ) {
+    event.currentTarget.value = '';
+  }
 </script>
 
 <label class="file relative inline-block cursor-pointer">
@@ -28,7 +34,7 @@
     type="file"
     tabindex="0"
     bind:files
-    onclick={(e) => (e.currentTarget.value = '')}
+    onclick={onClick}
     class="m-0 min-w-0 opacity-0"
     accept=".geojson,.json"
   />

--- a/src/lib/components/shared/FileInput.svelte
+++ b/src/lib/components/shared/FileInput.svelte
@@ -8,6 +8,7 @@
   let { id = '', file = null, onfilechange }: Props = $props();
 
   let files: FileList | null = $state(null);
+  let fileInput: HTMLInputElement;
 
   $effect(() => {
     if (files) {
@@ -16,16 +17,11 @@
   });
 
   $effect(() => {
-    if (!file) {
+    if (!file && fileInput) {
+      fileInput.value = '';
       files = null;
     }
   });
-
-  function onClick(
-    event: MouseEvent & { currentTarget: EventTarget & HTMLInputElement }
-  ) {
-    event.currentTarget.value = '';
-  }
 </script>
 
 <label class="file relative inline-block cursor-pointer">
@@ -33,9 +29,9 @@
     {id}
     type="file"
     tabindex="0"
+    bind:this={fileInput}
     bind:files
-    onclick={onClick}
-    class="m-0 min-w-0 opacity-0"
+    class="sr-only"
     accept=".geojson,.json"
   />
   <span

--- a/src/lib/components/shared/FileInput.svelte
+++ b/src/lib/components/shared/FileInput.svelte
@@ -14,6 +14,12 @@
       onfilechange(files[0]);
     }
   });
+
+  $effect(() => {
+    if (!file) {
+      files = null;
+    }
+  });
 </script>
 
 <label class="file relative inline-block cursor-pointer">
@@ -22,6 +28,7 @@
     type="file"
     tabindex="0"
     bind:files
+    onclick={(e) => (e.currentTarget.value = '')}
     class="m-0 min-w-0 opacity-0"
     accept=".geojson,.json"
   />

--- a/src/lib/core/diff/index.ts
+++ b/src/lib/core/diff/index.ts
@@ -17,6 +17,7 @@ import type {
   QuantitativeColorScheme,
   RampDirection,
   SchemeDirection,
+  ThemeMode,
   TransformationCall,
   VisualizationType
 } from '$lib/types';
@@ -318,6 +319,7 @@ interface BasemapDiff {
   payload: {
     url: string;
     provider: BasemapProvider;
+    mode: ThemeMode;
   };
 }
 

--- a/src/lib/core/patch/map/index.ts
+++ b/src/lib/core/patch/map/index.ts
@@ -23,13 +23,15 @@ export async function patchMapDiffs(
         type: 'basemap',
         payload: {
           url: ir.basemap.url,
-          provider: ir.basemap.provider
+          provider: ir.basemap.provider,
+          mode: ir.basemap.mode
         }
       };
 
       // Apply the patch.
       ir.basemap.url = diff.payload.url;
       ir.basemap.provider = diff.payload.provider;
+      ir.basemap.mode = diff.payload.mode;
       break;
     }
     case 'zoom': {

--- a/src/lib/core/recon/map/index.ts
+++ b/src/lib/core/recon/map/index.ts
@@ -48,6 +48,11 @@ export async function reconMapDiffs(
           return { ...nextStyle, layers, sources };
         }
       });
+
+      // Append or remove the .dark class to the <main> element.
+      document
+        .querySelector<HTMLElement>('main')
+        ?.classList.toggle('dark', diff.payload.mode === 'dark');
       break;
     }
     case 'zoom': {

--- a/src/lib/stores/ir.ts
+++ b/src/lib/stores/ir.ts
@@ -7,7 +7,8 @@ export const ir = writable<CartoKitIR>({
   zoom: 4,
   basemap: {
     url: 'https://tiles.stadiamaps.com/styles/stamen_toner_lite.json',
-    provider: 'Stamen'
+    provider: 'Stamen',
+    mode: 'light'
   },
   projection: 'mercator',
   layers: {}

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -639,14 +639,15 @@ export interface HeatmapStyle {
  * Represents a basemap in cartokit.
  *
  * @property title The name of the basemap, set by the tile provider.
- * @property tileId The tile ID of the basemap, set by the tile pro-
- * vider.
+ * @property tileId The tile ID of the basemap, set by the tile provider.
  * @property src The source for the basemap thumbnail.
+ * @property mode The default mode of the basemap, either 'light' or 'dark'.
  */
 export interface Basemap {
   title: string;
   tileId: string;
   src: SvelteHTMLElements['enhanced:img']['src'];
+  mode: ThemeMode;
 }
 
 /**
@@ -749,3 +750,8 @@ export interface CartoKitBackendAnalysis extends CartoKitBackend {
   isFetchGeoJSONRequired: boolean;
   isGeoJSONNamespaceRequired: boolean;
 }
+
+/**
+ * Represents the color theme mode.
+ */
+export type ThemeMode = 'light' | 'dark';

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -694,6 +694,7 @@ export interface CartoKitIR {
   basemap: {
     url: string;
     provider: BasemapProvider;
+    mode: ThemeMode;
   };
   projection: Projection;
   layers: Record<string, CartoKitLayer>;

--- a/src/lib/utils/basemap.ts
+++ b/src/lib/utils/basemap.ts
@@ -141,7 +141,7 @@ const MAPTILER_BASEMAPS: Basemap[] = [
     mode: 'light'
   },
   { title: 'Dataviz', tileId: 'dataviz', src: Dataviz, mode: 'light' },
-  { title: 'Hybrid', tileId: 'hybrid', src: Hybrid, mode: 'light' },
+  { title: 'Hybrid', tileId: 'hybrid', src: Hybrid, mode: 'dark' },
   {
     title: 'Landscape Dark',
     tileId: 'landscape-dark',
@@ -169,7 +169,7 @@ const MAPTILER_BASEMAPS: Basemap[] = [
     mode: 'dark'
   },
   { title: 'Outdoor', tileId: 'outdoor-v2', src: OutdoorV2, mode: 'light' },
-  { title: 'Satellite', tileId: 'satellite', src: Satellite, mode: 'light' },
+  { title: 'Satellite', tileId: 'satellite', src: Satellite, mode: 'dark' },
   {
     title: 'Streets Dark',
     tileId: 'streets-v2-dark',
@@ -195,7 +195,7 @@ const MAPTILER_BASEMAPS: Basemap[] = [
     src: TonerV2Lite,
     mode: 'light'
   },
-  { title: 'Toner', tileId: 'toner-v2', src: TonerV2, mode: 'light' },
+  { title: 'Toner', tileId: 'toner-v2', src: TonerV2, mode: 'dark' },
   { title: 'Topo Dark', tileId: 'topo-v2-dark', src: TopoV2Dark, mode: 'dark' },
   {
     title: 'Topo Pastel',

--- a/src/lib/utils/basemap.ts
+++ b/src/lib/utils/basemap.ts
@@ -59,87 +59,203 @@ import StamenWatercolor from '$lib/assets/basemaps/stamen/stamen_watercolor.webp
 import type { Basemap, BasemapProvider } from '$lib/types';
 
 const CARTO_BASEMAPS: Basemap[] = [
-  { title: 'Dark Matter', tileId: 'dark-matter', src: DarkMatter },
-  { title: 'Positron', tileId: 'positron', src: Positron },
-  { title: 'Voyager', tileId: 'voyager', src: Voyager }
+  {
+    title: 'Dark Matter',
+    tileId: 'dark-matter',
+    src: DarkMatter,
+    mode: 'dark'
+  },
+  { title: 'Positron', tileId: 'positron', src: Positron, mode: 'light' },
+  { title: 'Voyager', tileId: 'voyager', src: Voyager, mode: 'light' }
 ];
 
 const MAPTILER_BASEMAPS: Basemap[] = [
-  { title: 'Aquarelle Dark', tileId: 'aquarelle-dark', src: AquarelleDark },
-  { title: 'Aquarelle Vivid', tileId: 'aquarelle-vivid', src: AquarelleVivid },
-  { title: 'Aquarelle', tileId: 'aquarelle', src: Aquarelle },
-  { title: 'Backdrop Dark', tileId: 'backdrop-dark', src: BackdropDark },
-  { title: 'Backdrop Light', tileId: 'backdrop-light', src: BackdropLight },
-  { title: 'Backdrop', tileId: 'backdrop', src: Backdrop },
-  { title: 'Basic Dark', tileId: 'basic-v2-dark', src: BasicV2Dark },
-  { title: 'Basic Light', tileId: 'basic-v2-light', src: BasicV2Light },
-  { title: 'Basic', tileId: 'basic-v2', src: BasicV2 },
-  { title: 'Bright Dark', tileId: 'bright-v2-dark', src: BrightV2Dark },
-  { title: 'Bright Light', tileId: 'bright-v2-light', src: BrightV2Light },
+  {
+    title: 'Aquarelle Dark',
+    tileId: 'aquarelle-dark',
+    src: AquarelleDark,
+    mode: 'dark'
+  },
+  {
+    title: 'Aquarelle Vivid',
+    tileId: 'aquarelle-vivid',
+    src: AquarelleVivid,
+    mode: 'light'
+  },
+  { title: 'Aquarelle', tileId: 'aquarelle', src: Aquarelle, mode: 'light' },
+  {
+    title: 'Backdrop Dark',
+    tileId: 'backdrop-dark',
+    src: BackdropDark,
+    mode: 'dark'
+  },
+  {
+    title: 'Backdrop Light',
+    tileId: 'backdrop-light',
+    src: BackdropLight,
+    mode: 'light'
+  },
+  { title: 'Backdrop', tileId: 'backdrop', src: Backdrop, mode: 'light' },
+  {
+    title: 'Basic Dark',
+    tileId: 'basic-v2-dark',
+    src: BasicV2Dark,
+    mode: 'dark'
+  },
+  {
+    title: 'Basic Light',
+    tileId: 'basic-v2-light',
+    src: BasicV2Light,
+    mode: 'light'
+  },
+  { title: 'Basic', tileId: 'basic-v2', src: BasicV2, mode: 'light' },
+  {
+    title: 'Bright Dark',
+    tileId: 'bright-v2-dark',
+    src: BrightV2Dark,
+    mode: 'dark'
+  },
+  {
+    title: 'Bright Light',
+    tileId: 'bright-v2-light',
+    src: BrightV2Light,
+    mode: 'light'
+  },
   {
     title: 'Bright Pastel',
     tileId: 'bright-v2-pastel',
-    src: BrightV2Pastel
+    src: BrightV2Pastel,
+    mode: 'light'
   },
-  { title: 'Bright', tileId: 'bright-v2', src: BrightV2 },
-  { title: 'Dataviz Dark', tileId: 'dataviz-dark', src: DatavizDark },
-  { title: 'Dataviz Light', tileId: 'dataviz-light', src: DatavizLight },
-  { title: 'Dataviz', tileId: 'dataviz', src: Dataviz },
-  { title: 'Hybrid', tileId: 'hybrid', src: Hybrid },
-  { title: 'Landscape Dark', tileId: 'landscape-dark', src: LandscapeDark },
-  { title: 'Landscape Vivid', tileId: 'landscape-vivid', src: LandscapeVivid },
-  { title: 'Landscape', tileId: 'landscape', src: Landscape },
-  { title: 'Ocean', tileId: 'ocean', src: Ocean },
-  { title: 'Openstreetmap', tileId: 'openstreetmap', src: Openstreetmap },
-  { title: 'Outdoor Dark', tileId: 'outdoor-v2-dark', src: OutdoorV2Dark },
-  { title: 'Outdoor', tileId: 'outdoor-v2', src: OutdoorV2 },
-  { title: 'Satellite', tileId: 'satellite', src: Satellite },
-  { title: 'Streets Dark', tileId: 'streets-v2-dark', src: StreetsV2Dark },
+  { title: 'Bright', tileId: 'bright-v2', src: BrightV2, mode: 'light' },
+  {
+    title: 'Dataviz Dark',
+    tileId: 'dataviz-dark',
+    src: DatavizDark,
+    mode: 'dark'
+  },
+  {
+    title: 'Dataviz Light',
+    tileId: 'dataviz-light',
+    src: DatavizLight,
+    mode: 'light'
+  },
+  { title: 'Dataviz', tileId: 'dataviz', src: Dataviz, mode: 'light' },
+  { title: 'Hybrid', tileId: 'hybrid', src: Hybrid, mode: 'light' },
+  {
+    title: 'Landscape Dark',
+    tileId: 'landscape-dark',
+    src: LandscapeDark,
+    mode: 'dark'
+  },
+  {
+    title: 'Landscape Vivid',
+    tileId: 'landscape-vivid',
+    src: LandscapeVivid,
+    mode: 'light'
+  },
+  { title: 'Landscape', tileId: 'landscape', src: Landscape, mode: 'light' },
+  { title: 'Ocean', tileId: 'ocean', src: Ocean, mode: 'light' },
+  {
+    title: 'Openstreetmap',
+    tileId: 'openstreetmap',
+    src: Openstreetmap,
+    mode: 'light'
+  },
+  {
+    title: 'Outdoor Dark',
+    tileId: 'outdoor-v2-dark',
+    src: OutdoorV2Dark,
+    mode: 'dark'
+  },
+  { title: 'Outdoor', tileId: 'outdoor-v2', src: OutdoorV2, mode: 'light' },
+  { title: 'Satellite', tileId: 'satellite', src: Satellite, mode: 'light' },
+  {
+    title: 'Streets Dark',
+    tileId: 'streets-v2-dark',
+    src: StreetsV2Dark,
+    mode: 'dark'
+  },
   {
     title: 'Streets Light',
     tileId: 'streets-v2-light',
-    src: StreetsV2Light
+    src: StreetsV2Light,
+    mode: 'light'
   },
   {
     title: 'Streets Pastel',
     tileId: 'streets-v2-pastel',
-    src: StreetsV2Pastel
+    src: StreetsV2Pastel,
+    mode: 'light'
   },
-  { title: 'Streets', tileId: 'streets-v2', src: StreetsV2 },
-  { title: 'Toner Lite', tileId: 'toner-v2-lite', src: TonerV2Lite },
-  { title: 'Toner', tileId: 'toner-v2', src: TonerV2 },
-  { title: 'Topo Dark', tileId: 'topo-v2-dark', src: TopoV2Dark },
-  { title: 'Topo Pastel', tileId: 'topo-v2-pastel', src: TopoV2Pastel },
+  { title: 'Streets', tileId: 'streets-v2', src: StreetsV2, mode: 'light' },
+  {
+    title: 'Toner Lite',
+    tileId: 'toner-v2-lite',
+    src: TonerV2Lite,
+    mode: 'light'
+  },
+  { title: 'Toner', tileId: 'toner-v2', src: TonerV2, mode: 'light' },
+  { title: 'Topo Dark', tileId: 'topo-v2-dark', src: TopoV2Dark, mode: 'dark' },
+  {
+    title: 'Topo Pastel',
+    tileId: 'topo-v2-pastel',
+    src: TopoV2Pastel,
+    mode: 'light'
+  },
   {
     title: 'Topo Topographique',
     tileId: 'topo-v2-topographique',
-    src: TopoV2Topographique
+    src: TopoV2Topographique,
+    mode: 'light'
   },
-  { title: 'Topo', tileId: 'topo-v2', src: TopoV2 },
-  { title: 'Winter Dark', tileId: 'winter-v2-dark', src: WinterV2Dark },
-  { title: 'Winter', tileId: 'winter-v2', src: WinterV2 }
+  { title: 'Topo', tileId: 'topo-v2', src: TopoV2, mode: 'light' },
+  {
+    title: 'Winter Dark',
+    tileId: 'winter-v2-dark',
+    src: WinterV2Dark,
+    mode: 'dark'
+  },
+  { title: 'Winter', tileId: 'winter-v2', src: WinterV2, mode: 'light' }
 ];
 
 const STAMEN_BASEMAPS: Basemap[] = [
-  { title: 'Terrain', tileId: 'stamen_terrain', src: StamenTerrain },
-  { title: 'Toner Lite', tileId: 'stamen_toner_lite', src: StamenTonerLite },
-  { title: 'Toner', tileId: 'stamen_toner', src: StamenToner },
-  { title: 'Watercolor', tileId: 'stamen_watercolor', src: StamenWatercolor }
+  {
+    title: 'Terrain',
+    tileId: 'stamen_terrain',
+    src: StamenTerrain,
+    mode: 'light'
+  },
+  {
+    title: 'Toner Lite',
+    tileId: 'stamen_toner_lite',
+    src: StamenTonerLite,
+    mode: 'light'
+  },
+  { title: 'Toner', tileId: 'stamen_toner', src: StamenToner, mode: 'dark' },
+  {
+    title: 'Watercolor',
+    tileId: 'stamen_watercolor',
+    src: StamenWatercolor,
+    mode: 'light'
+  }
 ];
 
 const STADIA_MAPS_BASEMAPS: Basemap[] = [
   {
     title: 'Alidade Smooth Dark',
     tileId: 'alidade_smooth_dark',
-    src: AlidadeSmoothDark
+    src: AlidadeSmoothDark,
+    mode: 'dark'
   },
   {
     title: 'Alidade Smooth',
     tileId: 'alidade_smooth',
-    src: AlidadeSmooth
+    src: AlidadeSmooth,
+    mode: 'light'
   },
-  { title: 'OSM Bright', tileId: 'osm_bright', src: OsmBright },
-  { title: 'Outdoors', tileId: 'outdoors', src: Outdoors }
+  { title: 'OSM Bright', tileId: 'osm_bright', src: OsmBright, mode: 'light' },
+  { title: 'Outdoors', tileId: 'outdoors', src: Outdoors, mode: 'light' }
 ];
 
 export const BASEMAPS: Record<BasemapProvider, Basemap[]> = {

--- a/src/lib/utils/keybinding.ts
+++ b/src/lib/utils/keybinding.ts
@@ -24,6 +24,7 @@ export function registerKeybinding(
     }
 
     if (event.key === key && (!requireShift || event.shiftKey)) {
+      event.preventDefault();
       callback();
     }
   });

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -124,7 +124,7 @@
   }
 </script>
 
-<main class="absolute inset-0 overflow-hidden">
+<main class="absolute inset-0 overflow-hidden dark:bg-black">
   <div
     class={[
       'maplibregl-map relative h-full w-full',

--- a/src/routes/llm/+server.ts
+++ b/src/routes/llm/+server.ts
@@ -638,7 +638,8 @@ const Basemap = z.union(
     return basemaps.map((basemap) =>
       z.object({
         provider: z.literal(provider),
-        url: z.literal(TILE_URLS[provider as BasemapProvider](basemap.tileId))
+        url: z.literal(TILE_URLS[provider as BasemapProvider](basemap.tileId)),
+        mode: z.literal(basemap.mode)
       })
     );
   })

--- a/tests/components/file-upload.spec.ts
+++ b/tests/components/file-upload.spec.ts
@@ -1,0 +1,132 @@
+import * as path from 'node:path';
+import * as url from 'node:url';
+
+import { test, expect } from '@playwright/test';
+
+const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
+
+const GEOJSON_PATH = path.join(
+  __dirname,
+  '../data/workflow-1/nyt-nasa-path-of-totality.json'
+);
+
+test.describe('file upload', () => {
+  test.beforeEach(async ({ page }) => {
+    // Navigate to cartokit, running on a local development server.
+    await page.goto('/');
+
+    if (page.url().includes('vercel.app')) {
+      // In Preview Vercel environments, ensure <vercel-live-feedback> does not
+      // intercept pointer events.
+      await page.locator('vercel-live-feedback').waitFor({ state: 'attached' });
+      await page.locator('vercel-live-feedback').evaluate((element) => {
+        element.style.pointerEvents = 'none';
+        element.style.zIndex = '-1';
+        element.style.display = 'none';
+      });
+    }
+
+    // Wait for the Open Editor button and Add Layer button to become enabled.
+    // These are proxies for the map reaching an idle state.
+    await expect(page.getByTestId('editor-toggle')).toBeEnabled({
+      timeout: 10000
+    });
+    await expect(page.getByTestId('add-layer-button')).toBeEnabled({
+      timeout: 10000
+    });
+  });
+
+  test('uploads a GeoJSON file and resets the From File form state', async ({
+    page
+  }) => {
+    // Open the Add Layer modal.
+    await page.getByTestId('add-layer-button').click();
+    await expect(page.getByTestId('add-layer-modal')).toBeVisible();
+
+    // Select the From File tab.
+    await page.getByRole('button', { name: 'From File' }).click();
+
+    // Upload the Path of Totality GeoJSON file.
+    await page.locator('#from-file-input').setInputFiles(GEOJSON_PATH);
+
+    // Specify the layer's Display Name.
+    await page.getByLabel('Display Name').fill('Path of Totality');
+
+    // Add the layer.
+    await page
+      .getByTestId('add-layer-modal')
+      .getByRole('button', { name: 'Add' })
+      .click();
+
+    // Wait for the loading indicator to disappear.
+    await page.getByTestId('loading-indicator').waitFor({ state: 'hidden' });
+
+    // Ensure the Add Layer modal is no longer visible.
+    await expect(page.getByTestId('add-layer-modal')).not.toBeVisible();
+
+    // Wait for MapLibre to render the Path of Totality layer.
+    //
+    // Tiles are generated on the fly by MapLibre, so we need to wait for them
+    // to load. In theory, we'd like to hook into MapLibre's event system to
+    // determine when the map is idle; however, we don't want to attach the map
+    // instance to the global window object just for the sake of testing.
+    await page.waitForTimeout(5000);
+
+    // Ensure the layer entry appears in the Layers Panel.
+    await expect(page.getByTestId('layer-entry')).toHaveCount(1);
+
+    // Reopen the Add Layer modal and return to the From File tab to confirm
+    // the form state has been reset.
+    await page.getByTestId('add-layer-button').click();
+    await expect(page.getByTestId('add-layer-modal')).toBeVisible();
+    await page.getByRole('button', { name: 'From File' }).click();
+
+    // The Display Name input should be empty.
+    await expect(page.getByLabel('Display Name')).toHaveValue('');
+
+    // The file input should display its default prompt.
+    await expect(
+      page.getByTestId('add-layer-modal').locator('label.file > span')
+    ).toHaveAttribute('data-content', 'Choose file...');
+
+    // The Add button should be disabled while no file or display name is set.
+    await expect(
+      page.getByTestId('add-layer-modal').getByRole('button', { name: 'Add' })
+    ).toBeDisabled();
+  });
+
+  test('uploads the same GeoJSON file twice in a row', async ({ page }) => {
+    for (const displayName of ['Path of Totality 1', 'Path of Totality 2']) {
+      // Open the Add Layer modal.
+      await page.getByTestId('add-layer-button').click();
+      await expect(page.getByTestId('add-layer-modal')).toBeVisible();
+
+      // Select the From File tab.
+      await page.getByRole('button', { name: 'From File' }).click();
+
+      // Upload the Path of Totality GeoJSON file.
+      await page.locator('#from-file-input').setInputFiles(GEOJSON_PATH);
+
+      // Specify the layer's Display Name.
+      await page.getByLabel('Display Name').fill(displayName);
+
+      // Add the layer.
+      await page
+        .getByTestId('add-layer-modal')
+        .getByRole('button', { name: 'Add' })
+        .click();
+
+      // Wait for the loading indicator to disappear.
+      await page.getByTestId('loading-indicator').waitFor({ state: 'hidden' });
+
+      // Ensure the Add Layer modal is no longer visible.
+      await expect(page.getByTestId('add-layer-modal')).not.toBeVisible();
+
+      // Wait for MapLibre to render the new layer.
+      await page.waitForTimeout(5000);
+    }
+
+    // Ensure both layer entries appear in the Layers Panel.
+    await expect(page.getByTestId('layer-entry')).toHaveCount(2);
+  });
+});


### PR DESCRIPTION
This PR adds initial scaffolding for handling dark mode based on the selected basemap. This is most noticeable in globe mode, where the `background-color` of the `body` element shows through.

| Before | After |
|--------|--------|
| <img width="3248" height="2112" alt="Globe rendering without adaptive dark mode." src="https://github.com/user-attachments/assets/19e4f5c5-af86-474d-baba-7e9b59c0bca2" /> | <img width="3248" height="2112" alt="Globe rendering with adaptive dark mode." src="https://github.com/user-attachments/assets/dba97ede-f5d8-496f-b358-e9e035f3dfe9" /> |

This will support future dark / light mode improvements using Tailwind's `dark:` variant.

There are also a small handful of bug fixes rolled up into this one.

1. Support uploading the same file twice in a row. (On Chromium browsers, the `value` attribute will not change when selecting the same file a second time, though Firefox will dispatch a `change` event).
2. Add keybinding and tooltip for the LLM chat.
3. Properly reset the form state when loading data either **From API** or **From File**.
4. Support non-visible fills in the **Point** legend.