### PR TITLE
fix: Fix regression in code generation cauased by undefined source-layer.

### DIFF
--- a/src/lib/codegen/codegen-layer.ts
+++ b/src/lib/codegen/codegen-layer.ts
@@ -9,10 +9,10 @@ import type { CartoKitLayer } from '$lib/types';
  * accompanying call to add the layer to the map.
  */
 export function codegenLayer(layer: CartoKitLayer): string {
-  const sourceLayerExpr =
+  const sourceLayer =
     layer.source.type === 'vector'
-      ? `'source-layer': '${layer.source.sourceLayerId}',`
-      : undefined;
+      ? `'source-layer': '${layer.source.sourceLayerId}',\n`
+      : '';
 
   switch (layer.type) {
     case 'Point':
@@ -25,8 +25,7 @@ export function codegenLayer(layer: CartoKitLayer): string {
         map.addLayer({
           id: '${layer.id}',
           source: '${layer.id}',
-          ${sourceLayerExpr}
-          type: 'circle',
+          ${sourceLayer}type: 'circle',
           ${
             fill || stroke
               ? `paint: { ${[fill, stroke].filter(Boolean).join(',\n')} }`
@@ -42,8 +41,7 @@ export function codegenLayer(layer: CartoKitLayer): string {
         map.addLayer({
           id: '${layer.id}',
           source: '${layer.id}',
-          ${sourceLayerExpr}
-          type: 'line',
+          ${sourceLayer}type: 'line',
           ${stroke ? `paint: { ${stroke} }` : ''}
         });
       `;
@@ -57,8 +55,7 @@ export function codegenLayer(layer: CartoKitLayer): string {
         fillLayer = `map.addLayer({
           id: '${layer.id}',
           source: '${layer.id}',
-          ${sourceLayerExpr}
-          type: 'fill',
+          ${sourceLayer}type: 'fill',
           ${fill ? `paint: { ${fill} }` : ''}
         });`;
       }
@@ -68,8 +65,7 @@ export function codegenLayer(layer: CartoKitLayer): string {
         strokeLayer = `map.addLayer({
           id: '${layer.id}-stroke',
           source: '${layer.id}',
-          ${sourceLayerExpr}
-          type: 'line',
+          ${sourceLayer}type: 'line',
           ${stroke ? `paint: { ${stroke} }` : ''}
         });`;
       }
@@ -81,8 +77,7 @@ export function codegenLayer(layer: CartoKitLayer): string {
       const fillLayer = `map.addLayer({
         id: '${layer.id}',
         source: '${layer.id}',
-        ${sourceLayerExpr}
-        type: 'fill',
+        ${sourceLayer}type: 'fill',
         ${fill ? `paint: { ${fill} }` : ''}
       });`;
 
@@ -93,8 +88,7 @@ export function codegenLayer(layer: CartoKitLayer): string {
         strokeLayer = `map.addLayer({
           id: '${layer.id}-stroke',
           source: '${layer.id}',
-          ${sourceLayerExpr}
-          type: 'line',
+          ${sourceLayer}type: 'line',
           ${stroke ? `paint: { ${stroke} }` : ''}
         });`;
       }
@@ -108,8 +102,7 @@ export function codegenLayer(layer: CartoKitLayer): string {
         map.addLayer({
           id: '${layer.id}',
           source: '${layer.id}',
-          ${sourceLayerExpr}
-          type: 'heatmap',
+          ${sourceLayer}type: 'heatmap',
           paint: { ${display} }
         });
       `;

--- a/tests/codegen/basic.spec.ts
+++ b/tests/codegen/basic.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('basic codegen', () => {
+  test.beforeEach(async ({ page }) => {
+    // Navigate to cartokit, running on a local development server.
+    await page.goto('/');
+
+    if (page.url().includes('vercel.app')) {
+      // In Preview Vercel environments, ensure <vercel-live-feedback> does not
+      // intercept pointer events.
+      await page.locator('vercel-live-feedback').waitFor({ state: 'attached' });
+      await page.locator('vercel-live-feedback').evaluate((element) => {
+        element.style.pointerEvents = 'none';
+        element.style.zIndex = '-1';
+        element.style.display = 'none';
+      });
+    }
+
+    // Wait for the Open Editor button and Add Layer button to become enabled.
+    // These are proxies for the map reaching an idle state.
+    await expect(page.getByTestId('editor-toggle')).toBeEnabled({
+      timeout: 10000
+    });
+    await expect(page.getByTestId('add-layer-button')).toBeEnabled({
+      timeout: 10000
+    });
+
+    // Open the Add Layer modal.
+    await page.getByTestId('add-layer-button').click();
+    await expect(page.getByTestId('add-layer-modal')).toBeVisible();
+
+    // Select the From Gallery tab.
+    await page.getByRole('button', { name: 'From Gallery' }).click();
+
+    // Select the Climate Impact Regions dataset. The modal closes automatically
+    // once the MapLibre source finishes loading.
+    await page.getByRole('button', { name: 'Climate Impact Regions' }).click();
+
+    // Ensure the Add Layer modal is no longer visible.
+    await expect(page.getByTestId('add-layer-modal')).not.toBeVisible();
+
+    // Wait for MapLibre to render the Climate Impact Regions layer.
+    //
+    // Tiles are generated on the fly by MapLibre, so we need to wait for them
+    // to load. In theory, we'd like to hook into MapLibre's event system to
+    // determine when the map is idle; however, we don't want to attach the map
+    // instance to the global window object just for the sake of testing.
+    await page.waitForTimeout(5000);
+  });
+
+  test('should generate code for a single-layer map', async ({ page }) => {
+    await page.getByTestId('editor-toggle').click();
+
+    await expect(page.getByTestId('program-editor')).toBeVisible();
+
+    // Verify that map.addLayer is called in the generated code.
+    const editor = page.getByTestId('program-editor');
+    const code = await editor.textContent();
+    expect(code).toContain('map.addLayer');
+  });
+});


### PR DESCRIPTION
#1731 introduced a regression in our code generation where we'd incorrectly introduce `undefined` in the call to `map.addLayer` when using GeoJSON sources, which do not require a `"source-layer"` to be specified. This PR fixes that regression and adds a basic Playwright test that should catch future cases where code generation fails on simple syntactic mistakes.