### PR TITLE
fix: Fix regression in deriveSize affecting Proportional Symbol layers.

### DIFF
--- a/src/lib/interaction/geometry.ts
+++ b/src/lib/interaction/geometry.ts
@@ -25,9 +25,9 @@ export function deriveSize(
     'interpolate',
     ['linear'],
     ['sqrt', ['get', layer.style.size.attribute]],
-    min,
+    Math.sqrt(min),
     rMin,
-    max,
+    Math.sqrt(max),
     rMax
   ];
 }


### PR DESCRIPTION
This PR fixes a bad regression in `deriveSize` from #1731.

Before #1731, we converted our data domain into sqrt-space via calling `Math.sqrt` inside the `d3.extent` call:

https://github.com/parkerziegler/cartokit/blob/4da9173c9d0002fd7ea44c198226ca17f55783d2/src/lib/interaction/geometry.ts#L25-L27

However, in the conversion over to grabbing min/max values from the catalog (good!), we forgot to port this conversion (bad!). This PR fixes things!