### PR TITLE
feat: Restore chat for authenticated preview users.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
-  "automerge": true,
+  "extends": ["config:recommended"],
   "automergeType": "pr",
   "automergeStrategy": "squash",
   "lockFileMaintenance": {
@@ -12,12 +11,17 @@
     {
       "matchDepTypes": ["devDependencies"],
       "matchPackageNames": ["lint", "prettier"],
+      "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
     },
     {
       "matchUpdateTypes": ["minor", "patch"],
       "matchCurrentVersion": "!/^0/",
       "automerge": true
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "automerge": false
     },
     {
       "matchPackageNames": ["zod"],

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -17,17 +17,12 @@ export async function load({ url }) {
 
   if (userId) {
     try {
-      const { ok } = await client.kv.namespaces.values.get(
-        KV_NAMESPACE_ID,
-        userId,
-        {
-          account_id: CLOUDFLARE_ACCOUNT_ID
-        }
-      );
+      await client.kv.namespaces.values.get(userId, {
+        namespace_id: KV_NAMESPACE_ID,
+        account_id: CLOUDFLARE_ACCOUNT_ID
+      });
 
-      if (ok) {
-        userExists = true;
-      }
+      userExists = true;
     } catch {
       userExists = false;
     }


### PR DESCRIPTION
We had a small regression in chat availability due to our Renovate config, which automerged a major (breaking) update to our `cloudflare` dependency. Chat availability isn't exercised in CI and only available to authenticated preview users, hence why it was not caught. This PR fixes the issue while also adjusting our Renovate config to prohibit major version updates.