### PR TITLE
fix: Handle negative values for linear scales on proportional symbol layers.

### DIFF
--- a/src/lib/codegen/codegen-paint.ts
+++ b/src/lib/codegen/codegen-paint.ts
@@ -51,7 +51,7 @@ export function codegenFill(layer: CartoKitLayer): string {
         layer.style.fill.type === 'Constant'
           ? withDefault('circle-color', layer.style.fill.color)
           : `'circle-color': ${JSON.stringify(deriveColorScale(layer.style.fill, layer.id))}`,
-        `'circle-radius': ${JSON.stringify(deriveSize(layer))}`,
+        `'circle-radius': ${JSON.stringify(deriveSize(layer.id, layer.style.size))}`,
         withDefault(
           'circle-opacity',
           layer.style.fill.visible ? layer.style.fill.opacity : 0

--- a/src/lib/components/legends/ProportionalSymbolLegend.svelte
+++ b/src/lib/components/legends/ProportionalSymbolLegend.svelte
@@ -9,6 +9,7 @@
     NumericCatalogEntry
   } from '$lib/types';
   import { hexWithOpacity } from '$lib/utils/color';
+  import { signedSqrt, signedSquare } from '$lib/utils/number';
 
   interface Props {
     layer: CartoKitProportionalSymbolLayer;
@@ -19,24 +20,26 @@
   let { min, max } = $derived(
     catalog.value[layer.id][layer.style.size.attribute] as NumericCatalogEntry
   );
-  let scale = $derived(
-    d3.scaleLinear([layer.style.size.min, layer.style.size.max], [min, max])
-  );
+  let domain = $derived([layer.style.size.min, layer.style.size.max]);
+  let range = $derived([signedSqrt(min), signedSqrt(max)]);
+  let scale = $derived(d3.scaleLinear(domain, range));
+  let extent = $derived(domain[1] - domain[0]);
 
   let circles = $derived([
     {
-      size: layer.style.size.max / 3,
-      value: scale(layer.style.size.max / 3)
+      size: extent / 3 + min,
+      value: signedSquare(scale(extent / 3 + min))
     },
     {
-      size: (layer.style.size.max * 2) / 3,
-      value: scale((layer.style.size.max * 2) / 3)
+      size: (extent * 2) / 3 + min,
+      value: signedSquare(scale((extent * 2) / 3 + min))
     },
     {
-      size: layer.style.size.max,
-      value: scale(layer.style.size.max)
+      size: extent + min,
+      value: signedSquare(scale(extent + min))
     }
   ]);
+
   let style = $derived(
     layer.style.fill.type === 'Constant'
       ? `background-color: ${hexWithOpacity(layer.style.fill.color, layer.style.fill.opacity)};
@@ -52,17 +55,14 @@
     layer.layout.visible ? 'opacity-100' : 'opacity-75'
   ]}
 >
-  <span class="text-xs font-semibold">{layer.style.size.attribute} →</span>
-  <div class="flex gap-2">
+  <span class="text-xs font-semibold">{layer.style.size.attribute} ↓</span>
+  <div class="grid grid-cols-[max-content_1fr] gap-2">
     {#each circles as circle (circle.value)}
-      <div class="flex flex-col items-center gap-2">
-        <span class="text-3xs">{circle.value.toFixed(2)}</span>
-        <div
-          class="bg-primary rounded-full border border-white"
-          style="width: {2 * circle.size}px; height: {2 *
-            circle.size}px;{style}"
-        ></div>
-      </div>
+      <div
+        class="bg-primary justify-self-center rounded-full border border-white"
+        style="width: {2 * circle.size}px; height: {2 * circle.size}px;{style}"
+      ></div>
+      <span class="text-3xs self-center">{circle.value.toFixed(2)}</span>
     {/each}
   </div>
   {#if layer.style.fill.visible && layer.style.fill.type === 'Categorical'}

--- a/src/lib/components/legends/ProportionalSymbolLegend.svelte
+++ b/src/lib/components/legends/ProportionalSymbolLegend.svelte
@@ -20,23 +20,23 @@
   let { min, max } = $derived(
     catalog.value[layer.id][layer.style.size.attribute] as NumericCatalogEntry
   );
-  let domain = $derived([layer.style.size.min, layer.style.size.max]);
-  let range = $derived([signedSqrt(min), signedSqrt(max)]);
+  let domain = $derived([signedSqrt(min), signedSqrt(max)]);
+  let range = $derived([layer.style.size.min, layer.style.size.max]);
   let scale = $derived(d3.scaleLinear(domain, range));
-  let extent = $derived(domain[1] - domain[0]);
+  let extent = $derived(range[1] - range[0]);
 
   let circles = $derived([
     {
-      size: extent / 3 + min,
-      value: signedSquare(scale(extent / 3 + min))
+      size: extent / 3 + range[0],
+      value: signedSquare(scale.invert(extent / 3 + range[0]))
     },
     {
-      size: (extent * 2) / 3 + min,
-      value: signedSquare(scale((extent * 2) / 3 + min))
+      size: (extent * 2) / 3 + range[0],
+      value: signedSquare(scale.invert((extent * 2) / 3 + range[0]))
     },
     {
-      size: extent + min,
-      value: signedSquare(scale(extent + min))
+      size: extent + range[0],
+      value: signedSquare(scale.invert(extent + range[0]))
     }
   ]);
 

--- a/src/lib/core/recon/layer-type/proportional-symbol.ts
+++ b/src/lib/core/recon/layer-type/proportional-symbol.ts
@@ -34,7 +34,7 @@ export function reconProportionalSymbol(
       map.value?.setPaintProperty(
         targetLayer.id,
         'circle-radius',
-        deriveSize(targetLayer)
+        deriveSize(targetLayer.id, targetLayer.style.size)
       );
       break;
     case 'Proportional Symbol':

--- a/src/lib/core/recon/size/index.ts
+++ b/src/lib/core/recon/size/index.ts
@@ -35,7 +35,7 @@ export async function reconSizeDiffs(
       map.value!.setPaintProperty(
         diff.layerId,
         'circle-radius',
-        deriveSize(layer)
+        deriveSize(layer.id, layer.style.size)
       );
       break;
     }

--- a/src/lib/interaction/geometry.spec.ts
+++ b/src/lib/interaction/geometry.spec.ts
@@ -1,0 +1,103 @@
+import { expect, test, describe } from 'vitest';
+
+import { deriveSize } from '$lib/interaction/geometry';
+import { catalog } from '$lib/state/catalog.svelte';
+import type { NumericCatalogEntry, ProportionalSymbolStyle } from '$lib/types';
+import { signedSqrt } from '$lib/utils/number';
+
+const LAYER_ID = 'test-layer';
+
+function buildStyle(attribute: string): ProportionalSymbolStyle {
+  return {
+    attribute,
+    min: 2,
+    max: 20
+  };
+}
+
+function setCatalogEntry(
+  layerId: string,
+  attribute: string,
+  min: number,
+  max: number
+): void {
+  const entry: NumericCatalogEntry = {
+    type: 'number',
+    quantiles: { domain: [] },
+    jenks: {
+      3: { breaks: [] },
+      4: { breaks: [] },
+      5: { breaks: [] },
+      6: { breaks: [] },
+      7: { breaks: [] },
+      8: { breaks: [] },
+      9: { breaks: [] }
+    },
+    min,
+    max,
+    unique: 2
+  };
+
+  catalog.value[layerId] = { [attribute]: entry };
+}
+
+describe('deriveSize', () => {
+  test('derives a square root scale when the attribute range is fully positive', () => {
+    const style = buildStyle('population');
+    setCatalogEntry(LAYER_ID, 'population', 10, 1000);
+
+    const result = deriveSize(LAYER_ID, style);
+
+    expect(result).toEqual([
+      'interpolate',
+      ['linear'],
+      ['sqrt', ['get', 'population']],
+      signedSqrt(10),
+      2,
+      signedSqrt(1000),
+      20
+    ]);
+  });
+
+  test('derives a signed square root scale when the attribute range crosses zero', () => {
+    const style = buildStyle('net_change');
+    setCatalogEntry(LAYER_ID, 'net_change', -50, 100);
+
+    const result = deriveSize(LAYER_ID, style);
+
+    expect(result).toEqual([
+      'interpolate',
+      ['linear'],
+      [
+        '*',
+        ['case', ['<', ['get', 'net_change'], 0], -1, 1],
+        ['sqrt', ['abs', ['get', 'net_change']]]
+      ],
+      signedSqrt(-50),
+      2,
+      signedSqrt(100),
+      20
+    ]);
+  });
+
+  test('derives a signed square root scale when the attribute range is fully negative', () => {
+    const style = buildStyle('temperature_deviation');
+    setCatalogEntry(LAYER_ID, 'temperature_deviation', -100, -10);
+
+    const result = deriveSize(LAYER_ID, style);
+
+    expect(result).toEqual([
+      'interpolate',
+      ['linear'],
+      [
+        '*',
+        ['case', ['<', ['get', 'temperature_deviation'], 0], -1, 1],
+        ['sqrt', ['abs', ['get', 'temperature_deviation']]]
+      ],
+      signedSqrt(-100),
+      2,
+      signedSqrt(-10),
+      20
+    ]);
+  });
+});

--- a/src/lib/interaction/geometry.ts
+++ b/src/lib/interaction/geometry.ts
@@ -1,33 +1,45 @@
 import type { ExpressionSpecification } from 'maplibre-gl';
 
 import { catalog } from '$lib/state/catalog.svelte';
-import type {
-  CartoKitProportionalSymbolLayer,
-  NumericCatalogEntry
-} from '$lib/types';
+import type { NumericCatalogEntry, ProportionalSymbolStyle } from '$lib/types';
+import { signedSqrt } from '$lib/utils/number';
 
 /**
  * Derive a MapLibre GL JS expression for a proportional symbol radius scale.
  *
- * @param layer The {@link CartoKitProportionalSymbolLayer} to derive a radius
- * scale for.
+ * @param layerId The id of the layer to derive a radius scale for.
+ * @param style The {@link ProportionalSymbolStyle} to derive a radius scale for.
  * @returns An {@link ExpressionSpecification} for a proportional symbol radius scale.
  */
 export function deriveSize(
-  layer: CartoKitProportionalSymbolLayer
+  layerId: string,
+  style: ProportionalSymbolStyle
 ): ExpressionSpecification {
-  const { min, max } = catalog.value[layer.id][
-    layer.style.size.attribute
+  const { min, max } = catalog.value[layerId][
+    style.attribute
   ] as NumericCatalogEntry;
-  const [rMin, rMax] = [layer.style.size.min, layer.style.size.max];
+  const [rMin, rMax] = [style.min, style.max];
+  const attribute = style.attribute;
+
+  // If the full range of the attribute is positive, we can take the square root
+  // directly; otherwise, ensure we preserve the sign to linear scales on ranges
+  // with negative values.
+  const attrExpression: ExpressionSpecification =
+    min >= 0 && max >= max
+      ? ['sqrt', ['get', attribute]]
+      : [
+          '*',
+          ['case', ['<', ['get', attribute], 0], -1, 1],
+          ['sqrt', ['abs', ['get', attribute]]]
+        ];
 
   return [
     'interpolate',
     ['linear'],
-    ['sqrt', ['get', layer.style.size.attribute]],
-    Math.sqrt(min),
+    attrExpression,
+    signedSqrt(min),
     rMin,
-    Math.sqrt(max),
+    signedSqrt(max),
     rMax
   ];
 }

--- a/src/lib/interaction/layer.ts
+++ b/src/lib/interaction/layer.ts
@@ -289,7 +289,7 @@ export function addLayer(map: maplibregl.Map, layer: CartoKitLayer): void {
         paint: {
           ...fillPaint,
           ...strokePaint,
-          'circle-radius': deriveSize(layer)
+          'circle-radius': deriveSize(layer.id, layer.style.size)
         }
       });
 

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -656,7 +656,7 @@ export type QuantitativeFill = QuantitativeStyle;
  * @property min The minimum size of the points.
  * @property max The maximum size of the points.
  */
-interface ProportionalSymbolStyle {
+export interface ProportionalSymbolStyle {
   attribute: string;
   min: number;
   max: number;

--- a/src/lib/utils/number.ts
+++ b/src/lib/utils/number.ts
@@ -1,8 +1,28 @@
 /**
+ * Take the square root of a number, preserving its sign.
+ *
+ * @param value The input value, e.g., -16.
+ * @returns The signed square root of the value, e.g., -4.
+ */
+export function signedSqrt(value: number): number {
+  return Math.sign(value) * Math.sqrt(Math.abs(value));
+}
+
+/**
+ * Get the square of a number, preserving its sign.
+ *
+ * @param value The input value, e.g., -4.
+ * @returns The signed square of the value, e.g., -16.
+ */
+export function signedSquare(value: number): number {
+  return Math.sign(value) * value * value;
+}
+
+/**
  * Convert a percent to a decimal.
  *
- * @param {number} percent – The input percent, e.g., 100.
- * @returns – The decimal value of the percent between 0 and 1.
+ * @param percent The input percent, e.g., 100.
+ * @returns The decimal value of the percent between 0 and 1.
  */
 export function percentToDecimal(percent: number): number {
   return percent / 100;
@@ -11,8 +31,8 @@ export function percentToDecimal(percent: number): number {
 /**
  * Convert a decimal to a percent string.
  *
- * @param {number} decimal – The input decimal value between 0 and 1, e.g., 0.5.
- * @returns – The formatted percent string.
+ * @param decimal The input decimal value between 0 and 1, e.g., 0.5.
+ * @returns The formatted percent string.
  */
 export function decimalToPercent(decimal: number): number {
   return decimal * 100;


### PR DESCRIPTION
This PR introduces correct handling for linear size scales on **Proportional Symbol** layers when the attribute domain includes at least one negative value. Previously, cartokit did not account for sign when taking the square root of attribute values, which could generate sizing scales with a minimum value of `null` (actually `NaN`, but coerced by `JSON.stringify` to `null`).

This PR fixes the bug by preserving the sign of attribute values, taking the square root of its absolute values. Code generation will only include sign handling when we cartokit determines that the domain of the visualized attribute is either fully negative or crosses 0; otherwise, we use the simpler expression taking square roots directly.