### PR TITLE
fix: Run Renovate twice a week instead of on every PR.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,23 +1,34 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "timezone": "America/Los_Angeles",
+  "schedule": ["* 0-4 * * 1,4"],
+  "minimumReleaseAge": "2 days",
   "automergeType": "pr",
   "automergeStrategy": "squash",
   "lockFileMaintenance": {
     "enabled": true,
-    "automerge": true
+    "automerge": true,
+    "schedule": ["* 0-4 * * 1"]
   },
   "packageRules": [
     {
       "matchDepTypes": ["devDependencies"],
-      "matchPackageNames": ["lint", "prettier"],
+      "matchPackageNames": ["/lint/", "prettier"],
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
     },
     {
       "matchUpdateTypes": ["minor", "patch"],
       "matchCurrentVersion": "!/^0/",
+      "groupName": "non-major dependencies",
       "automerge": true
+    },
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchCurrentVersion": "/^0/",
+      "groupName": "non-major 0.x dependencies",
+      "automerge": false
     },
     {
       "matchUpdateTypes": ["major"],


### PR DESCRIPTION
This PR aims to reduce the amount of churn we have in CI by running Renovate a bit less frequently and only running CI on dependencies whose [`minimumReleaseAge`](https://pnpm.io/supply-chain-security#delay-dependency-updates) is at least 2 days. Renovate should now run twice a week on Monday and Thursday!