### PR TITLE
feat: Add pitch and bearing diffs.

### DIFF
--- a/src/lib/codegen/codegen-map.ts
+++ b/src/lib/codegen/codegen-map.ts
@@ -54,6 +54,8 @@ export function codegenMap(
     style: ${codegenMapStyle(ir)},
     center: [${ir.center.join(', ')}],
     zoom: ${ir.zoom},
+    pitch: ${ir.pitch},
+    bearing: ${ir.bearing},
     ${analysis.library === 'mapbox' ? projection : ''}
   });
 

--- a/src/lib/codegen/codegen-map.ts
+++ b/src/lib/codegen/codegen-map.ts
@@ -4,6 +4,7 @@ import { codegenLayer } from '$lib/codegen/codegen-layer';
 import { codegenMapStyle } from '$lib/codegen/codegen-map-style';
 import { codegenProjection } from '$lib/codegen/codegen-projection';
 import { codegenSource } from '$lib/codegen/codegen-source';
+import { withDefault } from '$lib/codegen/utils';
 import type { CartoKitBackendAnalysis, CartoKitIR } from '$lib/types';
 
 /**
@@ -46,17 +47,23 @@ export function codegenMap(
   `
       : '';
 
+  const mapOptions = [
+    "container: 'map'",
+    `style: ${codegenMapStyle(ir)}`,
+    `center: [${ir.center.join(', ')}]`,
+    `zoom: ${ir.zoom}`,
+    withDefault('bearing', ir.bearing),
+    withDefault('pitch', ir.pitch),
+    `${analysis.library === 'mapbox' ? projection : ''}`
+  ]
+    .filter(Boolean)
+    .join(',\n');
+
   return `
   ${protocol}
 
   const map = new ${analysis.library}gl.Map({
-    container: 'map',
-    style: ${codegenMapStyle(ir)},
-    center: [${ir.center.join(', ')}],
-    zoom: ${ir.zoom},
-    pitch: ${ir.pitch},
-    bearing: ${ir.bearing},
-    ${analysis.library === 'mapbox' ? projection : ''}
+    ${mapOptions}
   });
 
   ${analysis.library === 'maplibre' ? projection : ''}

--- a/src/lib/codegen/codegen-paint.ts
+++ b/src/lib/codegen/codegen-paint.ts
@@ -1,24 +1,8 @@
+import { withDefault } from '$lib/codegen/utils';
 import { deriveColorRamp, deriveColorScale } from '$lib/interaction/color';
 import { deriveSize } from '$lib/interaction/geometry';
 import { deriveHeatmapWeight } from '$lib/interaction/weight';
 import type { CartoKitLayer } from '$lib/types';
-
-const DEFAULTS = {
-  'circle-radius': 5,
-  'fill-color': '#000000',
-  'line-color': '#000000',
-  'fill-opacity': 1,
-  'line-opacity': 1,
-  'line-width': 1,
-  'circle-color': '#000000',
-  'circle-opacity': 1,
-  'circle-stroke-color': '#000000',
-  'circle-stroke-width': 0,
-  'circle-stroke-opacity': 1,
-  'heatmap-radius': 30,
-  'heatmap-intensity': 1,
-  'heatmap-opacity': 1
-};
 
 /**
  * Generate a program fragment representing the layer's fill.
@@ -161,23 +145,4 @@ export function codegenStroke(layer: CartoKitLayer): string {
       return '';
     }
   }
-}
-
-/**
- * Return a program fragment representing a property-value pair,
- * unless the value is the same as the default value.
- *
- * @param property The property name.
- * @param cartokitValue The value of the property in the {@link CartoKitIR}.
- * @returns A (potentially empty) program fragment.
- */
-function withDefault<T extends string | number>(
-  property: keyof typeof DEFAULTS,
-  cartokitValue: T
-): string {
-  return cartokitValue !== DEFAULTS[property]
-    ? `'${property}': ${
-        typeof cartokitValue === 'string' ? `'${cartokitValue}'` : cartokitValue
-      }`
-    : '';
 }

--- a/src/lib/codegen/utils.ts
+++ b/src/lib/codegen/utils.ts
@@ -1,0 +1,37 @@
+const DEFAULTS = {
+  bearing: 0,
+  'circle-color': '#000000',
+  'circle-radius': 5,
+  'circle-opacity': 1,
+  'circle-stroke-color': '#000000',
+  'circle-stroke-opacity': 1,
+  'circle-stroke-width': 0,
+  'fill-color': '#000000',
+  'fill-opacity': 1,
+  'heatmap-intensity': 1,
+  'heatmap-opacity': 1,
+  'heatmap-radius': 30,
+  'line-color': '#000000',
+  'line-opacity': 1,
+  'line-width': 1,
+  pitch: 0
+};
+
+/**
+ * Return a program fragment representing a property-value pair,
+ * unless the value is the same as the default value.
+ *
+ * @param property The property name.
+ * @param cartokitValue The value of the property in the {@link CartoKitIR}.
+ * @returns A (potentially empty) program fragment.
+ */
+export function withDefault<T extends string | number>(
+  property: keyof typeof DEFAULTS,
+  cartokitValue: T
+): string {
+  return cartokitValue !== DEFAULTS[property]
+    ? `'${property}': ${
+        typeof cartokitValue === 'string' ? `'${cartokitValue}'` : cartokitValue
+      }`
+    : '';
+}

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -28,6 +28,8 @@
   let requestState: LLMRequestState = $derived({
     center: $ir.center,
     zoom: $ir.zoom,
+    pitch: $ir.pitch,
+    bearing: $ir.bearing,
     projection: $ir.projection,
     basemap: $ir.basemap,
     layers: Object.values($ir.layers)

--- a/src/lib/components/toolbar/ActionPicker.svelte
+++ b/src/lib/components/toolbar/ActionPicker.svelte
@@ -53,7 +53,9 @@
   function onDownloadMap() {
     const camera = {
       center: $ir.center,
-      zoom: $ir.zoom
+      zoom: $ir.zoom,
+      pitch: $ir.pitch,
+      bearing: $ir.bearing
     };
 
     downloadContentToFile(
@@ -93,6 +95,20 @@
           type: 'zoom',
           payload: {
             zoom: content.camera.zoom
+          }
+        });
+
+        await applyDiff({
+          type: 'pitch',
+          payload: {
+            pitch: content.camera.pitch
+          }
+        });
+
+        await applyDiff({
+          type: 'bearing',
+          payload: {
+            bearing: content.camera.bearing
           }
         });
       } catch (err) {

--- a/src/lib/core/diff/index.ts
+++ b/src/lib/core/diff/index.ts
@@ -357,6 +357,20 @@ interface CenterDiff {
   };
 }
 
+interface PitchDiff {
+  type: 'pitch';
+  payload: {
+    pitch: number;
+  };
+}
+
+interface BearingDiff {
+  type: 'bearing';
+  payload: {
+    bearing: number;
+  };
+}
+
 interface ProjectionDiff {
   type: 'projection';
   payload: {
@@ -420,6 +434,8 @@ export type CartoKitDiff =
   | BasemapDiff
   | ZoomDiff
   | CenterDiff
+  | PitchDiff
+  | BearingDiff
   | ProjectionDiff
   | UnknownDiff
   | ErrorDiff;
@@ -462,8 +478,9 @@ export async function applyDiff(
 
   ir.set(draftIR);
 
-  // Track diffs as they are applied, excluding center and zoom diffs.
-  if (execute.type !== 'center' && execute.type !== 'zoom') {
+  // Track diffs as they are applied, excluding center, zoom, pitch, and
+  // bearing diffs.
+  if (!['center', 'zoom', 'pitch', 'bearing'].includes(execute.type)) {
     diffs.push(execute);
   }
 }

--- a/src/lib/core/patch/map/index.ts
+++ b/src/lib/core/patch/map/index.ts
@@ -63,6 +63,32 @@ export async function patchMapDiffs(
       ir.center = [diff.payload.center.lng, diff.payload.center.lat];
       break;
     }
+    case 'pitch': {
+      // Derive the inverse diff prior to applying the patch.
+      inverse = {
+        type: 'pitch',
+        payload: {
+          pitch: ir.pitch
+        }
+      };
+
+      // Apply the patch.
+      ir.pitch = diff.payload.pitch;
+      break;
+    }
+    case 'bearing': {
+      // Derive the inverse diff prior to applying the patch.
+      inverse = {
+        type: 'bearing',
+        payload: {
+          bearing: ir.bearing
+        }
+      };
+
+      // Apply the patch.
+      ir.bearing = diff.payload.bearing;
+      break;
+    }
     case 'projection': {
       // Derive the inverse diff prior to applying the patch.
       inverse = {

--- a/src/lib/core/recon/map/index.ts
+++ b/src/lib/core/recon/map/index.ts
@@ -63,6 +63,14 @@ export async function reconMapDiffs(
       map.value!.setCenter(diff.payload.center);
       break;
     }
+    case 'pitch': {
+      map.value!.setPitch(diff.payload.pitch);
+      break;
+    }
+    case 'bearing': {
+      map.value!.setBearing(diff.payload.bearing);
+      break;
+    }
     case 'projection': {
       map.value!.setProjection({ type: diff.payload.projection });
       break;

--- a/src/lib/stores/ir.ts
+++ b/src/lib/stores/ir.ts
@@ -5,6 +5,8 @@ import type { CartoKitIR } from '$lib/types';
 export const ir = writable<CartoKitIR>({
   center: [-98.35, 39.5],
   zoom: 4,
+  pitch: 0,
+  bearing: 0,
   basemap: {
     url: 'https://tiles.stadiamaps.com/styles/stamen_toner_lite.json',
     provider: 'Stamen',

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -770,12 +770,16 @@ export type Projection = 'mercator' | 'globe';
  *
  * @property center - The current center coordinates of the map.
  * @property zoom - The current zoom level of the map.
+ * @property pitch - The current pitch of the map, in degrees.
+ * @property bearing - The current bearing of the map, in degrees.
  * @property basemap - The current basemap of the map.
  * @property layers - The current layers of the map.
  */
 export interface CartoKitIR {
   center: [number, number];
   zoom: number;
+  pitch: number;
+  bearing: number;
   basemap: {
     url: string;
     provider: BasemapProvider;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -90,7 +90,9 @@
       container: 'map',
       style: data.basemap.url,
       center: $ir.center,
-      zoom: $ir.zoom
+      zoom: $ir.zoom,
+      pitch: $ir.pitch,
+      bearing: $ir.bearing
     });
 
     // Add an event listener to handle feature deselection.
@@ -121,6 +123,22 @@
     map.on('zoom', (event) => {
       ir.update((ir) => {
         ir.zoom = event.target.getZoom();
+
+        return ir;
+      });
+    });
+
+    map.on('pitch', (event) => {
+      ir.update((ir) => {
+        ir.pitch = event.target.getPitch();
+
+        return ir;
+      });
+    });
+
+    map.on('rotate', (event) => {
+      ir.update((ir) => {
+        ir.bearing = event.target.getBearing();
 
         return ir;
       });

--- a/src/routes/llm/+server.ts
+++ b/src/routes/llm/+server.ts
@@ -21,7 +21,14 @@ const openai = new OpenAI({
 /**
  * Diffs that apply to the map instance.
  */
-const MAP_DIFFs = ['center', 'zoom', 'basemap', 'projection'];
+const MAP_DIFFs = [
+  'center',
+  'zoom',
+  'pitch',
+  'bearing',
+  'basemap',
+  'projection'
+];
 
 /**
  * Diffs accepted by every layer, regardless of its {@link LayerType}.
@@ -236,6 +243,8 @@ function buildRequestStatePrompt(requestState: LLMRequestState): string {
 
 Zoom: ${requestState.zoom}
 Center: lng ${lng}, lat ${lat}
+Pitch: ${requestState.pitch}
+Bearing: ${requestState.bearing}
 Projection: ${requestState.projection}
 Basemap: ${requestState.basemap.provider}, ${requestState.basemap.mode} mode
 
@@ -887,6 +896,16 @@ const CenterDiff = z.object({
   })
 });
 
+const PitchDiff = z.object({
+  type: z.literal('pitch'),
+  payload: z.object({ pitch: z.number().min(0).max(60) })
+});
+
+const BearingDiff = z.object({
+  type: z.literal('bearing'),
+  payload: z.object({ bearing: z.number().min(-180).max(180) })
+});
+
 const ProjectionDiff = z.object({
   type: z.literal('projection'),
   payload: z.object({
@@ -946,6 +965,8 @@ const DiffSchema = z.object({
       BasemapDiff,
       ZoomDiff,
       CenterDiff,
+      PitchDiff,
+      BearingDiff,
       ProjectionDiff,
       UnknownDiff
     ])

--- a/tests/core/download-map.spec.ts
+++ b/tests/core/download-map.spec.ts
@@ -96,7 +96,9 @@ test.describe('download-map', () => {
     cartokitVersion: packageJson.version,
     camera: {
       center: [-98.35, 39.5],
-      zoom: 4
+      zoom: 4,
+      pitch: 0,
+      bearing: 0
     },
     diffs: [
       {

--- a/tests/data/maps/map.ck.json
+++ b/tests/data/maps/map.ck.json
@@ -5,7 +5,9 @@
       -98.35,
       39.5
     ],
-    "zoom": 4
+    "zoom": 4,
+    "pitch": 0,
+    "bearing": 0
   },
   "diffs": [
     {


### PR DESCRIPTION
This PR adds support for `pitch` and `bearing` diffs in cartokit to support programmable camera state beyond `zoom` and `center`. This is mostly useful for upcoming work on a **Fill Extrusion** layer type. Similar to `center` and `zoom`, these diffs may be generated by the LLM integration, but otherwise callbacks in `+page.svelte` handle patching directly. Reconciliation is immediate via direct manipulation.